### PR TITLE
Preserve Seerr server IDs on update

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -15,6 +15,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func normalizeServerIdentity(id, fallbackID types.String, serverID, fallbackServerID types.Int64) (types.String, types.Int64) {
+	if serverID.IsNull() || serverID.IsUnknown() {
+		serverID = fallbackServerID
+	}
+
+	if id.IsNull() || id.IsUnknown() || strings.TrimSpace(id.ValueString()) == "" {
+		switch {
+		case !serverID.IsNull() && !serverID.IsUnknown():
+			id = types.StringValue(strconv.FormatInt(serverID.ValueInt64(), 10))
+		default:
+			id = fallbackID
+		}
+	}
+
+	return id, serverID
+}
+
 func mapFromTypesMap(ctx context.Context, input types.Map) (map[string]string, diag.Diagnostics) {
 	out := map[string]string{}
 	if input.IsNull() || input.IsUnknown() {

--- a/internal/provider/resource_radarr_server.go
+++ b/internal/provider/resource_radarr_server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -66,7 +67,12 @@ func (r *RadarrServerResource) Schema(_ context.Context, _ resource.SchemaReques
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"server_id": schema.Int64Attribute{Computed: true},
+			"server_id": schema.Int64Attribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
 			"name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -314,11 +320,18 @@ func (r *RadarrServerResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *RadarrServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state RadarrServerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var data RadarrServerModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.ID, data.ServerID = normalizeServerIdentity(data.ID, state.ID, data.ServerID, state.ServerID)
 	normalizedData, body, err := r.payload(ctx, data)
 	if err != nil {
 		resp.Diagnostics.AddError("Update Failed", err.Error())

--- a/internal/provider/resource_sonarr_server.go
+++ b/internal/provider/resource_sonarr_server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -68,7 +69,12 @@ func (r *SonarrServerResource) Schema(_ context.Context, _ resource.SchemaReques
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"server_id": schema.Int64Attribute{Computed: true},
+			"server_id": schema.Int64Attribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
 			"name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -338,11 +344,18 @@ func (r *SonarrServerResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *SonarrServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state SonarrServerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var data SonarrServerModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.ID, data.ServerID = normalizeServerIdentity(data.ID, state.ID, data.ServerID, state.ServerID)
 	normalizedData, body, err := r.payload(ctx, data)
 	if err != nil {
 		resp.Diagnostics.AddError("Update Failed", err.Error())


### PR DESCRIPTION
## Summary
- preserve computed \\server_id\\ values from prior state when updating typed Radarr and Sonarr server resources
- use \\UseStateForUnknown()\\ on \\server_id\\ so imported resources keep a stable identity in plans
- keep the state-written \\id\\ aligned with the preserved server ID

## Validation
- \\go test ./...\\
- local \\	ofu plan\\ against \\C:/Code/home-main-publish/terraform/arr-config\\ using a dev override of this provider
- local targeted \\	ofu apply -auto-approve\\ against the live Seerr/Radarr/Sonarr services via kubectl port-forward; both \\seerr_radarr_server.radarr\\ and \\seerr_sonarr_server.sonarr\\ imported and updated successfully without the post-apply unknown \\server_id\\ error