### PR TITLE
fix: handle discover slider drift and missing deletes

### DIFF
--- a/internal/provider/resource_discover_slider.go
+++ b/internal/provider/resource_discover_slider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -106,7 +107,7 @@ func (r *DiscoverSliderResource) Create(ctx context.Context, req resource.Create
 	}
 
 	data.ID = types.StringValue("settings")
-	resp.Diagnostics.Append(r.readSliders(ctx, &data)...)
+	resp.Diagnostics.Append(r.readManagedSliders(ctx, data.Sliders, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 func (r *DiscoverSliderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -117,53 +118,27 @@ func (r *DiscoverSliderResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	data.ID = types.StringValue("settings")
-	resp.Diagnostics.Append(r.readSliders(ctx, &data)...)
+	resp.Diagnostics.Append(r.readManagedSliders(ctx, data.Sliders, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(data.Sliders) == 0 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *DiscoverSliderResource) readSliders(ctx context.Context, data *DiscoverSliderModel) diag.Diagnostics {
+func (r *DiscoverSliderResource) readManagedSliders(ctx context.Context, managed []DiscoverSliderItemModel, data *DiscoverSliderModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	res, err := r.client.Request(ctx, "GET", "/api/v1/settings/discover", "", nil)
+	allSliders, err := r.fetchSliders(ctx)
 	if err != nil {
 		diags.AddError("Read Failed", err.Error())
 		return diags
 	}
 
-	if !StatusIsOK(res.StatusCode) {
-		diags.AddError("Read Failed", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
-		return diags
-	}
-
-	var apiSliders []map[string]any
-	if err := json.Unmarshal(res.Body, &apiSliders); err != nil {
-		diags.AddError("Read Failed", fmt.Sprintf("failed to decode response: %s", err))
-		return diags
-	}
-
-	data.Sliders = make([]DiscoverSliderItemModel, 0, len(apiSliders))
-	for _, s := range apiSliders {
-		item := DiscoverSliderItemModel{
-			ID:      r.toInt64(s["id"]),
-			Type:    r.toInt64(s["type"]),
-			Enabled: r.toBool(s["enabled"]),
-		}
-		if v, ok := s["isBuiltIn"].(bool); ok {
-			item.IsBuiltIn = types.BoolValue(v)
-		}
-		if v, ok := s["title"].(string); ok {
-			item.Title = types.StringValue(v)
-		} else {
-			item.Title = types.StringNull()
-		}
-		if v, ok := s["data"].(string); ok {
-			item.Data = types.StringValue(v)
-		} else {
-			item.Data = types.StringNull()
-		}
-		data.Sliders = append(data.Sliders, item)
-	}
-
+	data.Sliders = filterManagedSliders(allSliders, managed)
 	return diags
 }
 
@@ -180,16 +155,69 @@ func (r *DiscoverSliderResource) Update(ctx context.Context, req resource.Update
 	}
 
 	data.ID = types.StringValue("settings")
-	resp.Diagnostics.Append(r.readSliders(ctx, &data)...)
+	resp.Diagnostics.Append(r.readManagedSliders(ctx, data.Sliders, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *DiscoverSliderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// Deleting the singleton doesn't make sense to delete sliders from Seerr,
-	// but we could "reset" them if we wanted. For now, no-op.
+	var state DiscoverSliderModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.fetchSliders(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Delete Failed", err.Error())
+		return
+	}
+
+	remaining := make([]DiscoverSliderItemModel, 0, len(current))
+	matchedAny := false
+	for _, slider := range current {
+		if matchesAnyManagedSlider(slider, state.Sliders) {
+			matchedAny = true
+			continue
+		}
+		remaining = append(remaining, slider)
+	}
+
+	if !matchedAny {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err := r.replaceSliders(ctx, remaining); err != nil {
+		resp.Diagnostics.AddError("Delete Failed", err.Error())
+		return
+	}
 }
 
 func (r *DiscoverSliderResource) updateSliders(ctx context.Context, sliders []DiscoverSliderItemModel) error {
+	current, err := r.fetchSliders(ctx)
+	if err != nil {
+		return err
+	}
+
+	resolved := resolveSliderIDs(current, sliders)
+	managedKeys := make([]sliderKey, 0, len(resolved))
+	for _, slider := range resolved {
+		managedKeys = append(managedKeys, sliderIdentity(slider))
+	}
+
+	payload := make([]DiscoverSliderItemModel, 0, len(resolved)+len(current))
+	payload = append(payload, resolved...)
+	for _, slider := range current {
+		if slices.Contains(managedKeys, sliderIdentity(slider)) {
+			continue
+		}
+		payload = append(payload, slider)
+	}
+
+	return r.replaceSliders(ctx, payload)
+}
+
+func (r *DiscoverSliderResource) replaceSliders(ctx context.Context, sliders []DiscoverSliderItemModel) error {
 	payload := make([]map[string]any, 0, len(sliders))
 	for _, s := range sliders {
 		item := map[string]any{
@@ -226,6 +254,131 @@ func (r *DiscoverSliderResource) updateSliders(ctx context.Context, sliders []Di
 	}
 
 	return nil
+}
+
+func (r *DiscoverSliderResource) fetchSliders(ctx context.Context) ([]DiscoverSliderItemModel, error) {
+	res, err := r.client.Request(ctx, "GET", "/api/v1/settings/discover", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !StatusIsOK(res.StatusCode) {
+		return nil, fmt.Errorf("status %d: %s", res.StatusCode, string(res.Body))
+	}
+
+	var apiSliders []map[string]any
+	if err := json.Unmarshal(res.Body, &apiSliders); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	sliders := make([]DiscoverSliderItemModel, 0, len(apiSliders))
+	for _, s := range apiSliders {
+		item := DiscoverSliderItemModel{
+			ID:      r.toInt64(s["id"]),
+			Type:    r.toInt64(s["type"]),
+			Enabled: r.toBool(s["enabled"]),
+		}
+		if v, ok := s["isBuiltIn"].(bool); ok {
+			item.IsBuiltIn = types.BoolValue(v)
+		}
+		if v, ok := s["title"].(string); ok {
+			item.Title = types.StringValue(v)
+		} else {
+			item.Title = types.StringNull()
+		}
+		if v, ok := s["data"].(string); ok {
+			item.Data = types.StringValue(v)
+		} else {
+			item.Data = types.StringNull()
+		}
+		sliders = append(sliders, item)
+	}
+
+	return sliders, nil
+}
+
+type sliderKey struct {
+	ID    int64
+	Type  int64
+	Title string
+	Data  string
+}
+
+func sliderIdentity(slider DiscoverSliderItemModel) sliderKey {
+	key := sliderKey{
+		Type:  slider.Type.ValueInt64(),
+		Title: sliderStringValue(slider.Title),
+		Data:  sliderStringValue(slider.Data),
+	}
+	if !slider.ID.IsNull() && !slider.ID.IsUnknown() {
+		key.ID = slider.ID.ValueInt64()
+	}
+	return key
+}
+
+func sliderStringValue(v types.String) string {
+	if v.IsNull() || v.IsUnknown() {
+		return ""
+	}
+	return v.ValueString()
+}
+
+func slidersMatch(a, b DiscoverSliderItemModel) bool {
+	if !a.ID.IsNull() && !a.ID.IsUnknown() && !b.ID.IsNull() && !b.ID.IsUnknown() {
+		return a.ID.ValueInt64() == b.ID.ValueInt64()
+	}
+
+	return a.Type.ValueInt64() == b.Type.ValueInt64() &&
+		sliderStringValue(a.Title) == sliderStringValue(b.Title) &&
+		sliderStringValue(a.Data) == sliderStringValue(b.Data)
+}
+
+func resolveSliderIDs(current, desired []DiscoverSliderItemModel) []DiscoverSliderItemModel {
+	resolved := make([]DiscoverSliderItemModel, 0, len(desired))
+	used := make([]bool, len(current))
+
+	for _, slider := range desired {
+		resolvedSlider := slider
+		for idx, existing := range current {
+			if used[idx] || !slidersMatch(existing, slider) {
+				continue
+			}
+			used[idx] = true
+			resolvedSlider.ID = existing.ID
+			resolvedSlider.IsBuiltIn = existing.IsBuiltIn
+			break
+		}
+		resolved = append(resolved, resolvedSlider)
+	}
+
+	return resolved
+}
+
+func filterManagedSliders(current, managed []DiscoverSliderItemModel) []DiscoverSliderItemModel {
+	filtered := make([]DiscoverSliderItemModel, 0, len(managed))
+	used := make([]bool, len(current))
+
+	for _, target := range managed {
+		for idx, existing := range current {
+			if used[idx] || !slidersMatch(existing, target) {
+				continue
+			}
+			used[idx] = true
+			filtered = append(filtered, existing)
+			break
+		}
+	}
+
+	return filtered
+}
+
+func matchesAnyManagedSlider(slider DiscoverSliderItemModel, managed []DiscoverSliderItemModel) bool {
+	for _, target := range managed {
+		if slidersMatch(slider, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *DiscoverSliderResource) toInt64(v any) types.Int64 {

--- a/internal/provider/resource_discover_slider_test.go
+++ b/internal/provider/resource_discover_slider_test.go
@@ -1,0 +1,101 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolveSliderIDsReusesExistingIDs(t *testing.T) {
+	current := []DiscoverSliderItemModel{
+		{
+			ID:        types.Int64Value(101),
+			Type:      types.Int64Value(1),
+			IsBuiltIn: types.BoolValue(true),
+			Enabled:   types.BoolValue(true),
+		},
+		{
+			ID:      types.Int64Value(202),
+			Type:    types.Int64Value(9),
+			Enabled: types.BoolValue(true),
+			Title:   types.StringValue("Custom"),
+			Data:    types.StringValue("trending"),
+		},
+	}
+
+	desired := []DiscoverSliderItemModel{
+		{
+			Type:    types.Int64Value(1),
+			Enabled: types.BoolValue(false),
+		},
+		{
+			Type:    types.Int64Value(9),
+			Enabled: types.BoolValue(true),
+			Title:   types.StringValue("Custom"),
+			Data:    types.StringValue("trending"),
+		},
+	}
+
+	resolved := resolveSliderIDs(current, desired)
+	if got := resolved[0].ID.ValueInt64(); got != 101 {
+		t.Fatalf("expected built-in slider id 101, got %d", got)
+	}
+	if got := resolved[1].ID.ValueInt64(); got != 202 {
+		t.Fatalf("expected custom slider id 202, got %d", got)
+	}
+	if !resolved[0].IsBuiltIn.ValueBool() {
+		t.Fatal("expected built-in marker to be preserved")
+	}
+}
+
+func TestFilterManagedSlidersReturnsOnlyTrackedEntries(t *testing.T) {
+	current := []DiscoverSliderItemModel{
+		{ID: types.Int64Value(1), Type: types.Int64Value(1), Enabled: types.BoolValue(true)},
+		{ID: types.Int64Value(2), Type: types.Int64Value(2), Enabled: types.BoolValue(true)},
+		{ID: types.Int64Value(3), Type: types.Int64Value(4), Enabled: types.BoolValue(true)},
+	}
+	managed := []DiscoverSliderItemModel{
+		{ID: types.Int64Value(2), Type: types.Int64Value(2)},
+		{ID: types.Int64Value(3), Type: types.Int64Value(4)},
+	}
+
+	filtered := filterManagedSliders(current, managed)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 managed sliders, got %d", len(filtered))
+	}
+	if got := filtered[0].ID.ValueInt64(); got != 2 {
+		t.Fatalf("expected first managed slider id 2, got %d", got)
+	}
+	if got := filtered[1].ID.ValueInt64(); got != 3 {
+		t.Fatalf("expected second managed slider id 3, got %d", got)
+	}
+}
+
+func TestNotificationAgentMissingReturnsTrueFor404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`Unknown notification agent`))
+	}))
+	defer srv.Close()
+
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource := &NotificationClientResource{
+		agent:  "pushover",
+		client: NewClient(base, "abc123", "test-agent", false, 5*time.Second),
+	}
+
+	if !resource.notificationAgentMissing(t.Context()) {
+		t.Fatal("expected notificationAgentMissing to return true for missing agent")
+	}
+}

--- a/internal/provider/resource_notification_agent.go
+++ b/internal/provider/resource_notification_agent.go
@@ -796,6 +796,10 @@ func (r *NotificationClientResource) Delete(ctx context.Context, req resource.De
 	disablePayload := `{"enabled":false,"types":0,"options":{}}`
 	res, err := r.client.Request(ctx, "POST", notificationPath(r.agent), disablePayload, nil)
 	if err != nil {
+		if r.notificationAgentMissing(ctx) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Delete Failed", err.Error())
 		return
 	}
@@ -804,6 +808,15 @@ func (r *NotificationClientResource) Delete(ctx context.Context, req resource.De
 			resp.Diagnostics.AddWarning("Delete Error", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
 		}
 	}
+}
+
+func (r *NotificationClientResource) notificationAgentMissing(ctx context.Context) bool {
+	res, err := r.client.Request(ctx, "GET", notificationPath(r.agent), "", nil)
+	if err != nil {
+		return false
+	}
+
+	return res.StatusCode == 404 || strings.Contains(string(res.Body), "Unknown notification agent")
 }
 
 func (r *NotificationClientResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
## Summary
- prevent seerr_discover_slider from drifting by keeping only the managed slider subset in Terraform state while preserving unmanaged sliders remotely
- make discover slider delete idempotent by removing matching managed sliders from the live list and dropping state if they are already absent
- make notification agent delete tolerate POST timeouts when a follow-up GET confirms the agent is already missing
- add provider unit tests for slider reconciliation and the missing-agent fallback

## Testing
- go test ./internal/provider
