### PR TITLE
fix: normalize discover sliders and verify notification deletes

### DIFF
--- a/internal/provider/resource_discover_slider.go
+++ b/internal/provider/resource_discover_slider.go
@@ -137,7 +137,6 @@ func (r *DiscoverSliderResource) readManagedSliders(ctx context.Context, managed
 		diags.AddError("Read Failed", err.Error())
 		return diags
 	}
-
 	data.Sliders = filterManagedSliders(allSliders, managed)
 	return diags
 }
@@ -281,16 +280,8 @@ func (r *DiscoverSliderResource) fetchSliders(ctx context.Context) ([]DiscoverSl
 		if v, ok := s["isBuiltIn"].(bool); ok {
 			item.IsBuiltIn = types.BoolValue(v)
 		}
-		if v, ok := s["title"].(string); ok {
-			item.Title = types.StringValue(v)
-		} else {
-			item.Title = types.StringNull()
-		}
-		if v, ok := s["data"].(string); ok {
-			item.Data = types.StringValue(v)
-		} else {
-			item.Data = types.StringNull()
-		}
+		item.Title = discoverOptionalString(s["title"])
+		item.Data = discoverOptionalString(s["data"])
 		sliders = append(sliders, item)
 	}
 
@@ -398,4 +389,12 @@ func (r *DiscoverSliderResource) toBool(v any) types.Bool {
 		return types.BoolValue(b)
 	}
 	return types.BoolNull()
+}
+
+func discoverOptionalString(v any) types.String {
+	str, ok := v.(string)
+	if !ok || str == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(str)
 }

--- a/internal/provider/resource_discover_slider_test.go
+++ b/internal/provider/resource_discover_slider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -75,6 +76,52 @@ func TestFilterManagedSlidersReturnsOnlyTrackedEntries(t *testing.T) {
 	}
 }
 
+func TestDiscoverSliderReadNormalizesBlankOptionalFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/settings/discover" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{
+			"id":1,
+			"type":1,
+			"enabled":true,
+			"isBuiltIn":true,
+			"title":"",
+			"data":""
+		}]`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &DiscoverSliderResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+	data := DiscoverSliderModel{}
+
+	diags := r.readManagedSliders(context.Background(), []DiscoverSliderItemModel{{Type: types.Int64Value(1)}}, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(data.Sliders) != 1 {
+		t.Fatalf("expected 1 slider, got %d", len(data.Sliders))
+	}
+	if !data.Sliders[0].Title.IsNull() {
+		t.Fatalf("expected blank title to normalize to null, got %#v", data.Sliders[0].Title)
+	}
+	if !data.Sliders[0].Data.IsNull() {
+		t.Fatalf("expected blank data to normalize to null, got %#v", data.Sliders[0].Data)
+	}
+}
+
 func TestNotificationAgentMissingReturnsTrueFor404(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -95,7 +142,7 @@ func TestNotificationAgentMissingReturnsTrueFor404(t *testing.T) {
 		client: NewClient(base, "abc123", "test-agent", false, 5*time.Second),
 	}
 
-	if !resource.notificationAgentMissing(t.Context()) {
+	if !resource.notificationAgentMissing(context.Background()) {
 		t.Fatal("expected notificationAgentMissing to return true for missing agent")
 	}
 }

--- a/internal/provider/resource_notification_agent.go
+++ b/internal/provider/resource_notification_agent.go
@@ -796,8 +796,7 @@ func (r *NotificationClientResource) Delete(ctx context.Context, req resource.De
 	disablePayload := `{"enabled":false,"types":0,"options":{}}`
 	res, err := r.client.Request(ctx, "POST", notificationPath(r.agent), disablePayload, nil)
 	if err != nil {
-		if r.notificationAgentMissing(ctx) {
-			resp.State.RemoveResource(ctx)
+		if r.notificationDeleteConverged(ctx) {
 			return
 		}
 		resp.Diagnostics.AddError("Delete Failed", err.Error())
@@ -815,8 +814,27 @@ func (r *NotificationClientResource) notificationAgentMissing(ctx context.Contex
 	if err != nil {
 		return false
 	}
-
 	return res.StatusCode == 404 || strings.Contains(string(res.Body), "Unknown notification agent")
+}
+
+func (r *NotificationClientResource) notificationDeleteConverged(ctx context.Context) bool {
+	res, err := r.client.Request(ctx, "GET", notificationPath(r.agent), "", nil)
+	if err != nil {
+		return false
+	}
+	if res.StatusCode == 404 || strings.Contains(string(res.Body), "Unknown notification agent") {
+		return true
+	}
+	if !StatusIsOK(res.StatusCode) {
+		return false
+	}
+
+	var payload notificationAgentPayload
+	if err := json.Unmarshal(res.Body, &payload); err != nil {
+		return false
+	}
+
+	return !payload.Enabled && payload.Types == 0
 }
 
 func (r *NotificationClientResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_notification_agent_delete_test.go
+++ b/internal/provider/resource_notification_agent_delete_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func TestNotificationDeleteConvergedWhenDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/settings/notifications/pushover" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"enabled":false,"types":0,"options":{}}`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &NotificationClientResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+		agent:  "pushover",
+	}
+
+	if !r.notificationDeleteConverged(context.Background()) {
+		t.Fatal("expected disabled notification agent to be treated as converged")
+	}
+}
+
+func TestNotificationDeleteIgnoresTimeoutWhenAgentAlreadyDisabled(t *testing.T) {
+	var requestCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != "/api/v1/settings/notifications/pushover" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			time.Sleep(100 * time.Millisecond)
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"enabled":false,"types":0,"options":{}}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &NotificationClientResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, 25*time.Millisecond),
+		agent:  "pushover",
+	}
+
+	var resp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected delete to succeed after converged timeout, got %v", resp.Diagnostics)
+	}
+	if requestCount < 2 {
+		t.Fatalf("expected timeout recovery to issue a follow-up GET, got %d requests", requestCount)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize Seerr discover slider blank `title` and `data` values back to Terraform nulls
- treat notification deletes as successful when the disable POST times out but a follow-up read shows the agent is already disabled or gone
- add focused unit coverage for both failure modes

## Why
`home` applies are currently failing in two provider-specific ways:

1. `seerr_discover_slider` writes sliders with empty-string `title` / `data` values for built-in sliders, but the plan had those attributes unset. On the read after apply, the provider returned `""` instead of `null`, which triggers `Provider produced inconsistent result after apply`.
2. Notification cleanup can time out during delete even when Seerr has already converged to the disabled state. In that case the provider reports a hard failure even though a follow-up GET would show the resource is already effectively deleted.

## Changes
### Discover slider
- add `discoverOptionalString()` and use it when decoding `/api/v1/settings/discover`
- convert blank strings from the API into Terraform nulls for optional `title` and `data`
- this keeps read-after-write behavior aligned with plans that omit those fields

### Notification delete
- when the disable POST errors, issue a follow-up GET to the same notification endpoint
- if the agent now returns `404`, `Unknown notification agent`, or `{ enabled: false, types: 0 }`, treat delete as converged instead of failing the apply
- preserve the existing warning behavior for non-404 non-unknown non-2xx responses

## Tests
- `TestDiscoverSliderReadNormalizesBlankOptionalFields`
- `TestNotificationDeleteConvergedWhenDisabled`
- `TestNotificationDeleteIgnoresTimeoutWhenAgentAlreadyDisabled`
- `go test ./internal/provider/...`
- `go test ./...`

## Scope / follow-ups
This PR intentionally does not broaden the timeout-recovery pattern to notification create/update or other resource types. If we keep seeing timeout-after-success behavior outside delete paths, the next step is to add the same style of post-write convergence checks there too.
