### PR TITLE
[codex] Fix Seerr v3 settings compatibility

### DIFF
--- a/docs/data-sources/main_settings.md
+++ b/docs/data-sources/main_settings.md
@@ -19,21 +19,25 @@ Read Seerr main settings via /api/v1/settings/main.
 
 - `app_title` (String) The application title.
 - `application_url` (String) The application URL.
-- `csrf_protection` (Boolean) Whether CSRF protection is enabled.
-- `enable_report_an_issue` (Boolean) Whether the 'Report an Issue' feature is enabled.
+- `cache_images` (Boolean) Whether Seerr caches proxied images.
+- `csrf_protection` (Boolean, Deprecated) Whether CSRF protection is enabled.
+- `discover_region` (String) The Discover region used by Seerr.
+- `enable_report_an_issue` (Boolean, Deprecated) Whether the 'Report an Issue' feature is enabled.
 - `hide_available` (Boolean) Whether to hide available media.
-- `image_proxy` (Boolean) Whether the image proxy is enabled.
+- `image_proxy` (Boolean, Deprecated) Whether the image proxy is enabled.
 - `local_login` (Boolean) Whether local login is enabled.
 - `locale` (String) The application locale.
-- `movie_request_limit` (Number) The movie request limit.
-- `movie_requests_enabled` (Boolean) Whether movie requests are enabled.
+- `media_server_login` (Boolean) Whether media-server login is enabled.
+- `movie_request_limit` (Number, Deprecated) The movie request limit.
+- `movie_requests_enabled` (Boolean, Deprecated) Whether movie requests are enabled.
 - `new_plex_login` (Boolean) Whether the new Plex login is enabled.
 - `original_language` (String) The original language.
 - `partial_requests` (Boolean) Whether partial requests are allowed.
-- `plex_login` (Boolean) Whether Plex login is enabled.
-- `region` (String) The application region.
+- `plex_login` (Boolean, Deprecated) Whether Plex login is enabled.
+- `region` (String, Deprecated) The application region.
 - `response_json` (String) Raw JSON response body.
-- `series_request_limit` (Number) The series request limit.
-- `series_requests_enabled` (Boolean) Whether series requests are enabled.
+- `series_request_limit` (Number, Deprecated) The series request limit.
+- `series_requests_enabled` (Boolean, Deprecated) Whether series requests are enabled.
 - `status_code` (Number) HTTP status code.
-- `trust_proxy` (Boolean) Whether to trust the proxy.
+- `streaming_region` (String) The streaming region used by Seerr.
+- `trust_proxy` (Boolean, Deprecated) Whether to trust the proxy.

--- a/docs/resources/main_settings.md
+++ b/docs/resources/main_settings.md
@@ -29,22 +29,26 @@ resource "seerr_main_settings" "main" {
 
 - `app_title` (String) The application title.
 - `application_url` (String) The application URL.
-- `csrf_protection` (Boolean) Whether CSRF protection is enabled.
-- `enable_report_an_issue` (Boolean) Whether the 'Report an Issue' feature is enabled.
+- `cache_images` (Boolean) Whether Seerr caches proxied images.
+- `csrf_protection` (Boolean, Deprecated) Whether CSRF protection is enabled.
+- `discover_region` (String) The Discover region used by Seerr.
+- `enable_report_an_issue` (Boolean, Deprecated) Whether the 'Report an Issue' feature is enabled.
 - `hide_available` (Boolean) Whether to hide available media.
-- `image_proxy` (Boolean) Whether the image proxy is enabled.
+- `image_proxy` (Boolean, Deprecated) Whether the image proxy is enabled.
 - `local_login` (Boolean) Whether local login is enabled.
 - `locale` (String) The application locale.
-- `movie_request_limit` (Number) The movie request limit.
-- `movie_requests_enabled` (Boolean) Whether movie requests are enabled.
+- `media_server_login` (Boolean) Whether media-server login is enabled.
+- `movie_request_limit` (Number, Deprecated) The movie request limit.
+- `movie_requests_enabled` (Boolean, Deprecated) Whether movie requests are enabled.
 - `new_plex_login` (Boolean) Whether the new Plex login is enabled.
 - `original_language` (String) The original language.
 - `partial_requests` (Boolean) Whether partial requests are allowed.
-- `plex_login` (Boolean) Whether Plex login is enabled.
-- `region` (String) The application region.
-- `series_request_limit` (Number) The series request limit.
-- `series_requests_enabled` (Boolean) Whether series requests are enabled.
-- `trust_proxy` (Boolean) Whether to trust the proxy.
+- `plex_login` (Boolean, Deprecated) Whether Plex login is enabled.
+- `region` (String, Deprecated) The application region.
+- `series_request_limit` (Number, Deprecated) The series request limit.
+- `series_requests_enabled` (Boolean, Deprecated) Whether series requests are enabled.
+- `streaming_region` (String) The streaming region used by Seerr.
+- `trust_proxy` (Boolean, Deprecated) Whether to trust the proxy.
 
 ### Read-Only
 

--- a/internal/provider/data_source_main_settings.go
+++ b/internal/provider/data_source_main_settings.go
@@ -22,12 +22,16 @@ type MainSettingsDataSourceModel struct {
 	TrustProxy            types.Bool   `tfsdk:"trust_proxy"`
 	CSRFProtection        types.Bool   `tfsdk:"csrf_protection"`
 	ImageProxy            types.Bool   `tfsdk:"image_proxy"`
+	CacheImages           types.Bool   `tfsdk:"cache_images"`
 	Locale                types.String `tfsdk:"locale"`
+	DiscoverRegion        types.String `tfsdk:"discover_region"`
+	StreamingRegion       types.String `tfsdk:"streaming_region"`
 	Region                types.String `tfsdk:"region"`
 	OriginalLanguage      types.String `tfsdk:"original_language"`
 	HideAvailable         types.Bool   `tfsdk:"hide_available"`
 	PartialRequests       types.Bool   `tfsdk:"partial_requests"`
 	LocalLogin            types.Bool   `tfsdk:"local_login"`
+	MediaServerLogin      types.Bool   `tfsdk:"media_server_login"`
 	NewPlexLogin          types.Bool   `tfsdk:"new_plex_login"`
 	PlexLogin             types.Bool   `tfsdk:"plex_login"`
 	MovieRequestsEnabled  types.Bool   `tfsdk:"movie_requests_enabled"`
@@ -60,22 +64,38 @@ func (d *MainSettingsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 			"trust_proxy": schema.BoolAttribute{
 				MarkdownDescription: "Whether to trust the proxy.",
 				Computed:            true,
+				DeprecationMessage:  "`trust_proxy` moved to `seerr_network_settings` in Seerr v3.",
 			},
 			"csrf_protection": schema.BoolAttribute{
 				MarkdownDescription: "Whether CSRF protection is enabled.",
 				Computed:            true,
+				DeprecationMessage:  "`csrf_protection` moved to `seerr_network_settings` in Seerr v3.",
 			},
 			"image_proxy": schema.BoolAttribute{
 				MarkdownDescription: "Whether the image proxy is enabled.",
+				Computed:            true,
+				DeprecationMessage:  "Use `cache_images`; Seerr v3 exposes this setting as `cacheImages`.",
+			},
+			"cache_images": schema.BoolAttribute{
+				MarkdownDescription: "Whether Seerr caches proxied images.",
 				Computed:            true,
 			},
 			"locale": schema.StringAttribute{
 				MarkdownDescription: "The application locale.",
 				Computed:            true,
 			},
+			"discover_region": schema.StringAttribute{
+				MarkdownDescription: "The Discover region used by Seerr.",
+				Computed:            true,
+			},
+			"streaming_region": schema.StringAttribute{
+				MarkdownDescription: "The streaming region used by Seerr.",
+				Computed:            true,
+			},
 			"region": schema.StringAttribute{
 				MarkdownDescription: "The application region.",
 				Computed:            true,
+				DeprecationMessage:  "Use `streaming_region` and `discover_region`; Seerr v3 split the legacy region field.",
 			},
 			"original_language": schema.StringAttribute{
 				MarkdownDescription: "The original language.",
@@ -93,6 +113,10 @@ func (d *MainSettingsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				MarkdownDescription: "Whether local login is enabled.",
 				Computed:            true,
 			},
+			"media_server_login": schema.BoolAttribute{
+				MarkdownDescription: "Whether media-server login is enabled.",
+				Computed:            true,
+			},
 			"new_plex_login": schema.BoolAttribute{
 				MarkdownDescription: "Whether the new Plex login is enabled.",
 				Computed:            true,
@@ -100,26 +124,32 @@ func (d *MainSettingsDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 			"plex_login": schema.BoolAttribute{
 				MarkdownDescription: "Whether Plex login is enabled.",
 				Computed:            true,
+				DeprecationMessage:  "Use `media_server_login`; Seerr v3 generalized Plex login to media-server login.",
 			},
 			"movie_requests_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether movie requests are enabled.",
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 removed this main setting; use `partial_requests` and user quota settings instead.",
 			},
 			"series_requests_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether series requests are enabled.",
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 removed this main setting; use `partial_requests` and user quota settings instead.",
 			},
 			"enable_report_an_issue": schema.BoolAttribute{
 				MarkdownDescription: "Whether the 'Report an Issue' feature is enabled.",
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 no longer exposes this value from `/api/v1/settings/main`.",
 			},
 			"movie_request_limit": schema.Int64Attribute{
 				MarkdownDescription: "The movie request limit.",
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 moved request limits into user quota settings.",
 			},
 			"series_request_limit": schema.Int64Attribute{
 				MarkdownDescription: "The series request limit.",
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 moved request limits into user quota settings.",
 			},
 			"response_json": schema.StringAttribute{
 				MarkdownDescription: "Raw JSON response body.",
@@ -171,60 +201,29 @@ func (d *MainSettingsDataSource) Read(ctx context.Context, req datasource.ReadRe
 	data.StatusCode = types.Int64Value(int64(res.StatusCode))
 	data.ResponseJSON = types.StringValue(string(res.Body))
 
-	if v, ok := decoded["appTitle"].(string); ok {
-		data.AppTitle = types.StringValue(v)
-	}
-	if v, ok := decoded["applicationUrl"].(string); ok {
-		data.ApplicationURL = types.StringValue(v)
-	}
-	if v, ok := decoded["trustProxy"].(bool); ok {
-		data.TrustProxy = types.BoolValue(v)
-	}
-	if v, ok := decoded["csrfProtection"].(bool); ok {
-		data.CSRFProtection = types.BoolValue(v)
-	}
-	if v, ok := decoded["imageProxy"].(bool); ok {
-		data.ImageProxy = types.BoolValue(v)
-	}
-	if v, ok := decoded["locale"].(string); ok {
-		data.Locale = types.StringValue(v)
-	}
-	if v, ok := decoded["region"].(string); ok {
-		data.Region = types.StringValue(v)
-	}
-	if v, ok := decoded["originalLanguage"].(string); ok {
-		data.OriginalLanguage = types.StringValue(v)
-	}
-	if v, ok := decoded["hideAvailable"].(bool); ok {
-		data.HideAvailable = types.BoolValue(v)
-	}
-	if v, ok := decoded["partialRequests"].(bool); ok {
-		data.PartialRequests = types.BoolValue(v)
-	}
-	if v, ok := decoded["localLogin"].(bool); ok {
-		data.LocalLogin = types.BoolValue(v)
-	}
-	if v, ok := decoded["newPlexLogin"].(bool); ok {
-		data.NewPlexLogin = types.BoolValue(v)
-	}
-	if v, ok := decoded["plexLogin"].(bool); ok {
-		data.PlexLogin = types.BoolValue(v)
-	}
-	if v, ok := decoded["movieRequestsEnabled"].(bool); ok {
-		data.MovieRequestsEnabled = types.BoolValue(v)
-	}
-	if v, ok := decoded["seriesRequestsEnabled"].(bool); ok {
-		data.SeriesRequestsEnabled = types.BoolValue(v)
-	}
-	if v, ok := decoded["enableReportAnIssue"].(bool); ok {
-		data.EnableReportAnIssue = types.BoolValue(v)
-	}
-	if v, ok := decoded["movieRequestLimit"].(float64); ok {
-		data.MovieRequestLimit = types.Int64Value(int64(v))
-	}
-	if v, ok := decoded["seriesRequestLimit"].(float64); ok {
-		data.SeriesRequestLimit = types.Int64Value(int64(v))
-	}
+	values := decodeMainSettings(decoded)
+	data.AppTitle = values.AppTitle
+	data.ApplicationURL = values.ApplicationURL
+	data.TrustProxy = values.TrustProxy
+	data.CSRFProtection = values.CSRFProtection
+	data.ImageProxy = values.ImageProxy
+	data.CacheImages = values.CacheImages
+	data.Locale = values.Locale
+	data.DiscoverRegion = values.DiscoverRegion
+	data.StreamingRegion = values.StreamingRegion
+	data.Region = values.Region
+	data.OriginalLanguage = values.OriginalLanguage
+	data.HideAvailable = values.HideAvailable
+	data.PartialRequests = values.PartialRequests
+	data.LocalLogin = values.LocalLogin
+	data.MediaServerLogin = values.MediaServerLogin
+	data.NewPlexLogin = values.NewPlexLogin
+	data.PlexLogin = values.PlexLogin
+	data.MovieRequestsEnabled = values.MovieRequestsEnabled
+	data.SeriesRequestsEnabled = values.SeriesRequestsEnabled
+	data.EnableReportAnIssue = values.EnableReportAnIssue
+	data.MovieRequestLimit = values.MovieRequestLimit
+	data.SeriesRequestLimit = values.SeriesRequestLimit
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/data_source_notification_agents.go
+++ b/internal/provider/data_source_notification_agents.go
@@ -82,42 +82,67 @@ func (d *NotificationAgentsDataSource) Configure(_ context.Context, req datasour
 func (d *NotificationAgentsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data NotificationAgentsDataSourceModel
 
-	// Fetch notification settings
-	res, err := d.client.Request(ctx, "GET", "/api/v1/settings/notifications", "", nil)
+	agents, err := d.readNotificationAgentSummaries(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Read Failed", err.Error())
 		return
 	}
-	if !StatusIsOK(res.StatusCode) {
-		resp.Diagnostics.AddError("Read Failed", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
-		return
-	}
 
-	var settings map[string]any
-	if err := json.Unmarshal(res.Body, &settings); err != nil {
-		resp.Diagnostics.AddError("Read Failed", fmt.Sprintf("failed to decode response: %s", err))
-		return
-	}
-
-	// The API returns a map where keys are agent names
-	for agentName, agentData := range settings {
-		if agentMap, ok := agentData.(map[string]any); ok {
-			agent := NotificationAgentSummaryModel{
-				Agent: types.StringValue(agentName),
-			}
-
-			if enabled, ok := agentMap["enabled"].(bool); ok {
-				agent.Enabled = types.BoolValue(enabled)
-			}
-			if embed, ok := agentMap["embedPoster"].(bool); ok {
-				agent.EmbedPoster = types.BoolValue(embed)
-			}
-
-			data.Agents = append(data.Agents, agent)
-		}
-	}
-
+	data.Agents = agents
 	data.ID = types.StringValue("all_notification_agents")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func notificationAggregateAgents() []string {
+	return []string{
+		"discord",
+		"slack",
+		"email",
+		"lunasea",
+		"telegram",
+		"pushbullet",
+		"pushover",
+		"ntfy",
+		"webhook",
+		"gotify",
+		"webpush",
+	}
+}
+
+func (d *NotificationAgentsDataSource) readNotificationAgentSummaries(ctx context.Context) ([]NotificationAgentSummaryModel, error) {
+	agents := []NotificationAgentSummaryModel{}
+	for _, agentName := range notificationAggregateAgents() {
+		res, err := d.client.Request(ctx, "GET", notificationPath(agentName), "", nil)
+		if err != nil {
+			return nil, err
+		}
+		if res.StatusCode == 404 {
+			continue
+		}
+		if !StatusIsOK(res.StatusCode) {
+			return nil, fmt.Errorf("%s: status %d: %s", agentName, res.StatusCode, string(res.Body))
+		}
+
+		var agentMap map[string]any
+		if err := json.Unmarshal(res.Body, &agentMap); err != nil {
+			return nil, fmt.Errorf("%s: failed to decode response: %s", agentName, err)
+		}
+
+		agent := NotificationAgentSummaryModel{
+			Agent:       types.StringValue(agentName),
+			Enabled:     types.BoolNull(),
+			EmbedPoster: types.BoolNull(),
+		}
+		if enabled, ok := boolValueFromAny(agentMap["enabled"]); ok {
+			agent.Enabled = types.BoolValue(enabled)
+		}
+		if embed, ok := boolValueFromAny(agentMap["embedPoster"]); ok {
+			agent.EmbedPoster = types.BoolValue(embed)
+		}
+
+		agents = append(agents, agent)
+	}
+
+	return agents, nil
 }

--- a/internal/provider/data_source_notification_agents_test.go
+++ b/internal/provider/data_source_notification_agents_test.go
@@ -1,10 +1,67 @@
 package provider
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestNotificationAgentsDataSourceReadsPerAgentEndpoints(t *testing.T) {
+	rootCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/settings/notifications":
+			rootCalled = true
+			http.NotFound(w, r)
+		case "/api/v1/settings/notifications/discord":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"enabled":true,"embedPoster":false}`))
+		case "/api/v1/settings/notifications/ntfy":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"enabled":false,"embedPoster":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := &NotificationAgentsDataSource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+	agents, err := d.readNotificationAgentSummaries(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rootCalled {
+		t.Fatal("aggregate notification endpoint should not be requested")
+	}
+	if got, want := len(agents), 2; got != want {
+		t.Fatalf("expected %d agents, got %d", want, got)
+	}
+	if got := agents[0].Agent.ValueString(); got != "discord" {
+		t.Fatalf("expected first agent discord, got %q", got)
+	}
+	if got := agents[0].Enabled.ValueBool(); !got {
+		t.Fatalf("expected discord enabled true, got %v", got)
+	}
+	if got := agents[1].Agent.ValueString(); got != "ntfy" {
+		t.Fatalf("expected second agent ntfy, got %q", got)
+	}
+	if got := agents[1].EmbedPoster.ValueBool(); !got {
+		t.Fatalf("expected ntfy embed_poster true, got %v", got)
+	}
+}
 
 func TestAccNotificationAgentsDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_main_settings.go
+++ b/internal/provider/resource_main_settings.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	boolvalidator "github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	stringvalidator "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -27,12 +30,16 @@ type MainSettingsModel struct {
 	TrustProxy            types.Bool   `tfsdk:"trust_proxy"`
 	CSRFProtection        types.Bool   `tfsdk:"csrf_protection"`
 	ImageProxy            types.Bool   `tfsdk:"image_proxy"`
+	CacheImages           types.Bool   `tfsdk:"cache_images"`
 	Locale                types.String `tfsdk:"locale"`
+	DiscoverRegion        types.String `tfsdk:"discover_region"`
+	StreamingRegion       types.String `tfsdk:"streaming_region"`
 	Region                types.String `tfsdk:"region"`
 	OriginalLanguage      types.String `tfsdk:"original_language"`
 	HideAvailable         types.Bool   `tfsdk:"hide_available"`
 	PartialRequests       types.Bool   `tfsdk:"partial_requests"`
 	LocalLogin            types.Bool   `tfsdk:"local_login"`
+	MediaServerLogin      types.Bool   `tfsdk:"media_server_login"`
 	NewPlexLogin          types.Bool   `tfsdk:"new_plex_login"`
 	PlexLogin             types.Bool   `tfsdk:"plex_login"`
 	MovieRequestsEnabled  types.Bool   `tfsdk:"movie_requests_enabled"`
@@ -74,14 +81,25 @@ func (r *MainSettingsResource) Schema(_ context.Context, _ resource.SchemaReques
 				MarkdownDescription: "Whether to trust the proxy.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "`trust_proxy` moved to `seerr_network_settings` in Seerr v3.",
 			},
 			"csrf_protection": schema.BoolAttribute{
 				MarkdownDescription: "Whether CSRF protection is enabled.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "`csrf_protection` moved to `seerr_network_settings` in Seerr v3.",
 			},
 			"image_proxy": schema.BoolAttribute{
 				MarkdownDescription: "Whether the image proxy is enabled.",
+				Optional:            true,
+				Computed:            true,
+				DeprecationMessage:  "Use `cache_images`; Seerr v3 exposes this setting as `cacheImages`.",
+				Validators: []validator.Bool{
+					boolvalidator.ConflictsWith(path.MatchRoot("cache_images")),
+				},
+			},
+			"cache_images": schema.BoolAttribute{
+				MarkdownDescription: "Whether Seerr caches proxied images.",
 				Optional:            true,
 				Computed:            true,
 			},
@@ -90,10 +108,25 @@ func (r *MainSettingsResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:            true,
 				Computed:            true,
 			},
+			"discover_region": schema.StringAttribute{
+				MarkdownDescription: "The Discover region used by Seerr.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"streaming_region": schema.StringAttribute{
+				MarkdownDescription: "The streaming region used by Seerr.",
+				Optional:            true,
+				Computed:            true,
+			},
 			"region": schema.StringAttribute{
 				MarkdownDescription: "The application region.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Use `streaming_region` and `discover_region`; Seerr v3 split the legacy region field.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("streaming_region")),
+					stringvalidator.ConflictsWith(path.MatchRoot("discover_region")),
+				},
 			},
 			"original_language": schema.StringAttribute{
 				MarkdownDescription: "The original language.",
@@ -115,6 +148,11 @@ func (r *MainSettingsResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:            true,
 				Computed:            true,
 			},
+			"media_server_login": schema.BoolAttribute{
+				MarkdownDescription: "Whether media-server login is enabled.",
+				Optional:            true,
+				Computed:            true,
+			},
 			"new_plex_login": schema.BoolAttribute{
 				MarkdownDescription: "Whether the new Plex login is enabled.",
 				Optional:            true,
@@ -124,31 +162,40 @@ func (r *MainSettingsResource) Schema(_ context.Context, _ resource.SchemaReques
 				MarkdownDescription: "Whether Plex login is enabled.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Use `media_server_login`; Seerr v3 generalized Plex login to media-server login.",
+				Validators: []validator.Bool{
+					boolvalidator.ConflictsWith(path.MatchRoot("media_server_login")),
+				},
 			},
 			"movie_requests_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether movie requests are enabled.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 removed this main setting; use `partial_requests` and user quota settings instead.",
 			},
 			"series_requests_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether series requests are enabled.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 removed this main setting; use `partial_requests` and user quota settings instead.",
 			},
 			"enable_report_an_issue": schema.BoolAttribute{
 				MarkdownDescription: "Whether the 'Report an Issue' feature is enabled.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 no longer exposes this value from `/api/v1/settings/main`.",
 			},
 			"movie_request_limit": schema.Int64Attribute{
 				MarkdownDescription: "The movie request limit.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 moved request limits into user quota settings.",
 			},
 			"series_request_limit": schema.Int64Attribute{
 				MarkdownDescription: "The series request limit.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage:  "Seerr v3 moved request limits into user quota settings.",
 			},
 			"response_json": schema.StringAttribute{
 				MarkdownDescription: "Raw JSON response body.",
@@ -177,25 +224,26 @@ func (r *MainSettingsResource) Configure(_ context.Context, req resource.Configu
 func (r *MainSettingsResource) buildPayload(data *MainSettingsModel) map[string]any {
 	payload := make(map[string]any)
 	if !data.AppTitle.IsNull() && !data.AppTitle.IsUnknown() {
-		payload["appTitle"] = data.AppTitle.ValueString()
+		payload["applicationTitle"] = data.AppTitle.ValueString()
 	}
 	if !data.ApplicationURL.IsNull() && !data.ApplicationURL.IsUnknown() {
 		payload["applicationUrl"] = data.ApplicationURL.ValueString()
 	}
-	if !data.TrustProxy.IsNull() && !data.TrustProxy.IsUnknown() {
-		payload["trustProxy"] = data.TrustProxy.ValueBool()
-	}
-	if !data.CSRFProtection.IsNull() && !data.CSRFProtection.IsUnknown() {
-		payload["csrfProtection"] = data.CSRFProtection.ValueBool()
-	}
-	if !data.ImageProxy.IsNull() && !data.ImageProxy.IsUnknown() {
-		payload["imageProxy"] = data.ImageProxy.ValueBool()
+	if !data.CacheImages.IsNull() && !data.CacheImages.IsUnknown() {
+		payload["cacheImages"] = data.CacheImages.ValueBool()
+	} else if !data.ImageProxy.IsNull() && !data.ImageProxy.IsUnknown() {
+		payload["cacheImages"] = data.ImageProxy.ValueBool()
 	}
 	if !data.Locale.IsNull() && !data.Locale.IsUnknown() {
 		payload["locale"] = data.Locale.ValueString()
 	}
-	if !data.Region.IsNull() && !data.Region.IsUnknown() {
-		payload["region"] = data.Region.ValueString()
+	if !data.DiscoverRegion.IsNull() && !data.DiscoverRegion.IsUnknown() {
+		payload["discoverRegion"] = data.DiscoverRegion.ValueString()
+	}
+	if !data.StreamingRegion.IsNull() && !data.StreamingRegion.IsUnknown() {
+		payload["streamingRegion"] = data.StreamingRegion.ValueString()
+	} else if !data.Region.IsNull() && !data.Region.IsUnknown() {
+		payload["streamingRegion"] = data.Region.ValueString()
 	}
 	if !data.OriginalLanguage.IsNull() && !data.OriginalLanguage.IsUnknown() {
 		payload["originalLanguage"] = data.OriginalLanguage.ValueString()
@@ -204,110 +252,176 @@ func (r *MainSettingsResource) buildPayload(data *MainSettingsModel) map[string]
 		payload["hideAvailable"] = data.HideAvailable.ValueBool()
 	}
 	if !data.PartialRequests.IsNull() && !data.PartialRequests.IsUnknown() {
-		payload["partialRequests"] = data.PartialRequests.ValueBool()
+		payload["partialRequestsEnabled"] = data.PartialRequests.ValueBool()
 	}
 	if !data.LocalLogin.IsNull() && !data.LocalLogin.IsUnknown() {
 		payload["localLogin"] = data.LocalLogin.ValueBool()
 	}
+	if !data.MediaServerLogin.IsNull() && !data.MediaServerLogin.IsUnknown() {
+		payload["mediaServerLogin"] = data.MediaServerLogin.ValueBool()
+	} else if !data.PlexLogin.IsNull() && !data.PlexLogin.IsUnknown() {
+		payload["mediaServerLogin"] = data.PlexLogin.ValueBool()
+	}
 	if !data.NewPlexLogin.IsNull() && !data.NewPlexLogin.IsUnknown() {
 		payload["newPlexLogin"] = data.NewPlexLogin.ValueBool()
-	}
-	if !data.PlexLogin.IsNull() && !data.PlexLogin.IsUnknown() {
-		payload["plexLogin"] = data.PlexLogin.ValueBool()
-	}
-	if !data.MovieRequestsEnabled.IsNull() && !data.MovieRequestsEnabled.IsUnknown() {
-		payload["movieRequestsEnabled"] = data.MovieRequestsEnabled.ValueBool()
-	}
-	if !data.SeriesRequestsEnabled.IsNull() && !data.SeriesRequestsEnabled.IsUnknown() {
-		payload["seriesRequestsEnabled"] = data.SeriesRequestsEnabled.ValueBool()
-	}
-	if !data.EnableReportAnIssue.IsNull() && !data.EnableReportAnIssue.IsUnknown() {
-		payload["enableReportAnIssue"] = data.EnableReportAnIssue.ValueBool()
-	}
-	if !data.MovieRequestLimit.IsNull() && !data.MovieRequestLimit.IsUnknown() {
-		payload["movieRequestLimit"] = data.MovieRequestLimit.ValueInt64()
-	}
-	if !data.SeriesRequestLimit.IsNull() && !data.SeriesRequestLimit.IsUnknown() {
-		payload["seriesRequestLimit"] = data.SeriesRequestLimit.ValueInt64()
 	}
 
 	return payload
 }
 
-func (r *MainSettingsResource) applyDecodedSettings(data *MainSettingsModel, decoded map[string]any) {
-	data.AppTitle = types.StringNull()
-	data.ApplicationURL = types.StringNull()
-	data.TrustProxy = types.BoolNull()
-	data.CSRFProtection = types.BoolNull()
-	data.ImageProxy = types.BoolNull()
-	data.Locale = types.StringNull()
-	data.Region = types.StringNull()
-	data.OriginalLanguage = types.StringNull()
-	data.HideAvailable = types.BoolNull()
-	data.PartialRequests = types.BoolNull()
-	data.LocalLogin = types.BoolNull()
-	data.NewPlexLogin = types.BoolNull()
-	data.PlexLogin = types.BoolNull()
-	data.MovieRequestsEnabled = types.BoolNull()
-	data.SeriesRequestsEnabled = types.BoolNull()
-	data.EnableReportAnIssue = types.BoolNull()
-	data.MovieRequestLimit = types.Int64Null()
-	data.SeriesRequestLimit = types.Int64Null()
+type mainSettingsDecodedValues struct {
+	AppTitle              types.String
+	ApplicationURL        types.String
+	TrustProxy            types.Bool
+	CSRFProtection        types.Bool
+	ImageProxy            types.Bool
+	CacheImages           types.Bool
+	Locale                types.String
+	DiscoverRegion        types.String
+	StreamingRegion       types.String
+	Region                types.String
+	OriginalLanguage      types.String
+	HideAvailable         types.Bool
+	PartialRequests       types.Bool
+	LocalLogin            types.Bool
+	MediaServerLogin      types.Bool
+	NewPlexLogin          types.Bool
+	PlexLogin             types.Bool
+	MovieRequestsEnabled  types.Bool
+	SeriesRequestsEnabled types.Bool
+	EnableReportAnIssue   types.Bool
+	MovieRequestLimit     types.Int64
+	SeriesRequestLimit    types.Int64
+}
 
-	if v, ok := decoded["appTitle"].(string); ok {
-		data.AppTitle = types.StringValue(v)
+func decodeMainSettings(decoded map[string]any) mainSettingsDecodedValues {
+	values := mainSettingsDecodedValues{
+		AppTitle:              types.StringNull(),
+		ApplicationURL:        types.StringNull(),
+		TrustProxy:            types.BoolNull(),
+		CSRFProtection:        types.BoolNull(),
+		ImageProxy:            types.BoolNull(),
+		CacheImages:           types.BoolNull(),
+		Locale:                types.StringNull(),
+		DiscoverRegion:        types.StringNull(),
+		StreamingRegion:       types.StringNull(),
+		Region:                types.StringNull(),
+		OriginalLanguage:      types.StringNull(),
+		HideAvailable:         types.BoolNull(),
+		PartialRequests:       types.BoolNull(),
+		LocalLogin:            types.BoolNull(),
+		MediaServerLogin:      types.BoolNull(),
+		NewPlexLogin:          types.BoolNull(),
+		PlexLogin:             types.BoolNull(),
+		MovieRequestsEnabled:  types.BoolNull(),
+		SeriesRequestsEnabled: types.BoolNull(),
+		EnableReportAnIssue:   types.BoolNull(),
+		MovieRequestLimit:     types.Int64Null(),
+		SeriesRequestLimit:    types.Int64Null(),
 	}
-	if v, ok := decoded["applicationUrl"].(string); ok {
-		data.ApplicationURL = types.StringValue(v)
+
+	if v, ok := stringValueFromAny(decoded["applicationTitle"]); ok {
+		values.AppTitle = types.StringValue(v)
+	} else if v, ok := stringValueFromAny(decoded["appTitle"]); ok {
+		values.AppTitle = types.StringValue(v)
 	}
-	if v, ok := decoded["trustProxy"].(bool); ok {
-		data.TrustProxy = types.BoolValue(v)
+	if v, ok := stringValueFromAny(decoded["applicationUrl"]); ok {
+		values.ApplicationURL = types.StringValue(v)
 	}
-	if v, ok := decoded["csrfProtection"].(bool); ok {
-		data.CSRFProtection = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["trustProxy"]); ok {
+		values.TrustProxy = types.BoolValue(v)
 	}
-	if v, ok := decoded["imageProxy"].(bool); ok {
-		data.ImageProxy = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["csrfProtection"]); ok {
+		values.CSRFProtection = types.BoolValue(v)
 	}
-	if v, ok := decoded["locale"].(string); ok {
-		data.Locale = types.StringValue(v)
+	if v, ok := boolValueFromAny(decoded["cacheImages"]); ok {
+		values.CacheImages = types.BoolValue(v)
+		values.ImageProxy = types.BoolValue(v)
+	} else if v, ok := boolValueFromAny(decoded["imageProxy"]); ok {
+		values.ImageProxy = types.BoolValue(v)
 	}
-	if v, ok := decoded["region"].(string); ok {
-		data.Region = types.StringValue(v)
+	if v, ok := stringValueFromAny(decoded["locale"]); ok {
+		values.Locale = types.StringValue(v)
 	}
-	if v, ok := decoded["originalLanguage"].(string); ok {
-		data.OriginalLanguage = types.StringValue(v)
+	if v, ok := stringValueFromAny(decoded["discoverRegion"]); ok {
+		values.DiscoverRegion = types.StringValue(v)
 	}
-	if v, ok := decoded["hideAvailable"].(bool); ok {
-		data.HideAvailable = types.BoolValue(v)
+	if v, ok := stringValueFromAny(decoded["streamingRegion"]); ok {
+		values.StreamingRegion = types.StringValue(v)
 	}
-	if v, ok := decoded["partialRequests"].(bool); ok {
-		data.PartialRequests = types.BoolValue(v)
+	if v, ok := stringValueFromAny(decoded["streamingRegion"]); ok && v != "" {
+		values.Region = types.StringValue(v)
+	} else if v, ok := stringValueFromAny(decoded["discoverRegion"]); ok {
+		values.Region = types.StringValue(v)
+	} else if v, ok := stringValueFromAny(decoded["region"]); ok {
+		values.Region = types.StringValue(v)
 	}
-	if v, ok := decoded["localLogin"].(bool); ok {
-		data.LocalLogin = types.BoolValue(v)
+	if v, ok := stringValueFromAny(decoded["originalLanguage"]); ok {
+		values.OriginalLanguage = types.StringValue(v)
 	}
-	if v, ok := decoded["newPlexLogin"].(bool); ok {
-		data.NewPlexLogin = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["hideAvailable"]); ok {
+		values.HideAvailable = types.BoolValue(v)
 	}
-	if v, ok := decoded["plexLogin"].(bool); ok {
-		data.PlexLogin = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["partialRequestsEnabled"]); ok {
+		values.PartialRequests = types.BoolValue(v)
+	} else if v, ok := boolValueFromAny(decoded["partialRequests"]); ok {
+		values.PartialRequests = types.BoolValue(v)
 	}
-	if v, ok := decoded["movieRequestsEnabled"].(bool); ok {
-		data.MovieRequestsEnabled = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["localLogin"]); ok {
+		values.LocalLogin = types.BoolValue(v)
 	}
-	if v, ok := decoded["seriesRequestsEnabled"].(bool); ok {
-		data.SeriesRequestsEnabled = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["mediaServerLogin"]); ok {
+		values.MediaServerLogin = types.BoolValue(v)
+		values.PlexLogin = types.BoolValue(v)
+	} else if v, ok := boolValueFromAny(decoded["plexLogin"]); ok {
+		values.PlexLogin = types.BoolValue(v)
 	}
-	if v, ok := decoded["enableReportAnIssue"].(bool); ok {
-		data.EnableReportAnIssue = types.BoolValue(v)
+	if v, ok := boolValueFromAny(decoded["newPlexLogin"]); ok {
+		values.NewPlexLogin = types.BoolValue(v)
 	}
-	if v, ok := decoded["movieRequestLimit"].(float64); ok {
-		data.MovieRequestLimit = types.Int64Value(int64(v))
+	if v, ok := boolValueFromAny(decoded["movieRequestsEnabled"]); ok {
+		values.MovieRequestsEnabled = types.BoolValue(v)
 	}
-	if v, ok := decoded["seriesRequestLimit"].(float64); ok {
-		data.SeriesRequestLimit = types.Int64Value(int64(v))
+	if v, ok := boolValueFromAny(decoded["seriesRequestsEnabled"]); ok {
+		values.SeriesRequestsEnabled = types.BoolValue(v)
 	}
+	if v, ok := boolValueFromAny(decoded["enableReportAnIssue"]); ok {
+		values.EnableReportAnIssue = types.BoolValue(v)
+	}
+	if v, ok := int64ValueFromAny(decoded["movieRequestLimit"]); ok {
+		values.MovieRequestLimit = types.Int64Value(v)
+	}
+	if v, ok := int64ValueFromAny(decoded["seriesRequestLimit"]); ok {
+		values.SeriesRequestLimit = types.Int64Value(v)
+	}
+
+	return values
+}
+
+func (r *MainSettingsResource) applyDecodedSettings(data *MainSettingsModel, decoded map[string]any) {
+	values := decodeMainSettings(decoded)
+	data.AppTitle = values.AppTitle
+	data.ApplicationURL = values.ApplicationURL
+	data.TrustProxy = values.TrustProxy
+	data.CSRFProtection = values.CSRFProtection
+	data.ImageProxy = values.ImageProxy
+	data.CacheImages = values.CacheImages
+	data.Locale = values.Locale
+	data.DiscoverRegion = values.DiscoverRegion
+	data.StreamingRegion = values.StreamingRegion
+	data.Region = values.Region
+	data.OriginalLanguage = values.OriginalLanguage
+	data.HideAvailable = values.HideAvailable
+	data.PartialRequests = values.PartialRequests
+	data.LocalLogin = values.LocalLogin
+	data.MediaServerLogin = values.MediaServerLogin
+	data.NewPlexLogin = values.NewPlexLogin
+	data.PlexLogin = values.PlexLogin
+	data.MovieRequestsEnabled = values.MovieRequestsEnabled
+	data.SeriesRequestsEnabled = values.SeriesRequestsEnabled
+	data.EnableReportAnIssue = values.EnableReportAnIssue
+	data.MovieRequestLimit = values.MovieRequestLimit
+	data.SeriesRequestLimit = values.SeriesRequestLimit
 }
 
 func (r *MainSettingsResource) refreshState(ctx context.Context, data *MainSettingsModel) error {

--- a/internal/provider/resource_main_settings_test.go
+++ b/internal/provider/resource_main_settings_test.go
@@ -41,6 +41,100 @@ func TestMainSettingsApplyDecodedSettingsClearsMissingValues(t *testing.T) {
 	}
 }
 
+func TestMainSettingsApplyDecodedSettingsReadsSeerrV3Keys(t *testing.T) {
+	r := &MainSettingsResource{}
+	var data MainSettingsModel
+
+	r.applyDecodedSettings(&data, map[string]any{
+		"applicationTitle":       "Seerr",
+		"applicationUrl":         "https://seerr.example",
+		"cacheImages":            true,
+		"locale":                 "fr",
+		"discoverRegion":         "",
+		"streamingRegion":        "FR",
+		"originalLanguage":       "",
+		"hideAvailable":          false,
+		"partialRequestsEnabled": true,
+		"localLogin":             true,
+		"mediaServerLogin":       true,
+		"newPlexLogin":           true,
+	})
+
+	if got := data.AppTitle.ValueString(); got != "Seerr" {
+		t.Fatalf("expected app title Seerr, got %q", got)
+	}
+	if got := data.CacheImages.ValueBool(); !got {
+		t.Fatalf("expected cache_images true, got %v", got)
+	}
+	if got := data.ImageProxy.ValueBool(); !got {
+		t.Fatalf("expected deprecated image_proxy alias true, got %v", got)
+	}
+	if got := data.StreamingRegion.ValueString(); got != "FR" {
+		t.Fatalf("expected streaming region FR, got %q", got)
+	}
+	if got := data.Region.ValueString(); got != "FR" {
+		t.Fatalf("expected deprecated region alias FR, got %q", got)
+	}
+	if got := data.PartialRequests.ValueBool(); !got {
+		t.Fatalf("expected partial requests true, got %v", got)
+	}
+	if got := data.MediaServerLogin.ValueBool(); !got {
+		t.Fatalf("expected media_server_login true, got %v", got)
+	}
+	if got := data.PlexLogin.ValueBool(); !got {
+		t.Fatalf("expected deprecated plex_login alias true, got %v", got)
+	}
+	if !data.TrustProxy.IsNull() {
+		t.Fatalf("expected moved trust_proxy to remain null from v3 main settings")
+	}
+}
+
+func TestMainSettingsBuildPayloadUsesSeerrV3Keys(t *testing.T) {
+	r := &MainSettingsResource{}
+	payload := r.buildPayload(&MainSettingsModel{
+		AppTitle:              types.StringValue("Seerr"),
+		ApplicationURL:        types.StringValue("https://seerr.example"),
+		ImageProxy:            types.BoolValue(true),
+		Locale:                types.StringValue("fr"),
+		DiscoverRegion:        types.StringValue(""),
+		Region:                types.StringValue("FR"),
+		OriginalLanguage:      types.StringValue(""),
+		HideAvailable:         types.BoolValue(false),
+		PartialRequests:       types.BoolValue(true),
+		LocalLogin:            types.BoolValue(true),
+		PlexLogin:             types.BoolValue(true),
+		NewPlexLogin:          types.BoolValue(true),
+		TrustProxy:            types.BoolValue(true),
+		CSRFProtection:        types.BoolValue(false),
+		MovieRequestsEnabled:  types.BoolValue(true),
+		SeriesRequestsEnabled: types.BoolValue(true),
+	})
+
+	if got := payload["applicationTitle"]; got != "Seerr" {
+		t.Fatalf("expected applicationTitle, got %#v", got)
+	}
+	if _, ok := payload["appTitle"]; ok {
+		t.Fatalf("did not expect legacy appTitle key in payload")
+	}
+	if got := payload["cacheImages"]; got != true {
+		t.Fatalf("expected cacheImages true from image_proxy alias, got %#v", got)
+	}
+	if got := payload["streamingRegion"]; got != "FR" {
+		t.Fatalf("expected streamingRegion FR from region alias, got %#v", got)
+	}
+	if got := payload["partialRequestsEnabled"]; got != true {
+		t.Fatalf("expected partialRequestsEnabled true, got %#v", got)
+	}
+	if got := payload["mediaServerLogin"]; got != true {
+		t.Fatalf("expected mediaServerLogin true from plex_login alias, got %#v", got)
+	}
+	for _, key := range []string{"trustProxy", "csrfProtection", "movieRequestsEnabled", "seriesRequestsEnabled"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("did not expect removed or moved key %q in payload", key)
+		}
+	}
+}
+
 func TestMainSettingsRefreshStateReadsCanonicalValues(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/internal/provider/resource_notification_agent_test.go
+++ b/internal/provider/resource_notification_agent_test.go
@@ -26,25 +26,23 @@ func sweepNotificationAgent(region string) error {
 	}
 
 	ctx := context.Background()
-	res, err := client.Request(ctx, "GET", "/api/v1/settings/notifications", "", nil)
-	if err != nil {
-		return fmt.Errorf("error fetching notification agents: %s", err)
-	}
-	if !StatusIsOK(res.StatusCode) {
-		return fmt.Errorf("error fetching notification agents: status %d", res.StatusCode)
-	}
-
-	var settings map[string]any
-	if err := json.Unmarshal(res.Body, &settings); err != nil {
-		return fmt.Errorf("error parsing notification agents: %s", err)
-	}
-
 	disablePayload := `{"enabled":false,"types":0,"options":{}}`
 
-	for agentName, agentData := range settings {
-		agentMap, ok := agentData.(map[string]any)
-		if !ok {
+	for _, agentName := range notificationAggregateAgents() {
+		res, err := client.Request(ctx, "GET", notificationPath(agentName), "", nil)
+		if err != nil {
+			return fmt.Errorf("error fetching notification agent %s: %s", agentName, err)
+		}
+		if res.StatusCode == 404 {
 			continue
+		}
+		if !StatusIsOK(res.StatusCode) {
+			return fmt.Errorf("error fetching notification agent %s: status %d", agentName, res.StatusCode)
+		}
+
+		var agentMap map[string]any
+		if err := json.Unmarshal(res.Body, &agentMap); err != nil {
+			return fmt.Errorf("error parsing notification agent %s: %s", agentName, err)
 		}
 
 		enabled, _ := agentMap["enabled"].(bool)


### PR DESCRIPTION
## Summary

- realign `seerr_main_settings` resource and data source with Seerr v3 main-settings keys such as `applicationTitle`, `partialRequestsEnabled`, `streamingRegion`, `discoverRegion`, and `mediaServerLogin`
- add canonical Terraform attributes for `cache_images`, `discover_region`, `streaming_region`, and `media_server_login` while keeping legacy aliases deprecated
- stop `seerr_notification_agents` from calling the removed aggregate notifications endpoint and read per-agent endpoints instead, skipping agents Seerr returns as 404
- update generated docs and notification cleanup tests for the new endpoint shape

Thanks @juherr for the thorough live Seerr v3.3.0 test report and field-by-field comparison.

Closes #74

## Validation

- `go test ./internal/provider`
- `go generate ./...`
- `gofmt -w` on touched Go files
- pre-push hook: `go generate ./...` and `gofmt -w .`
