### PR TITLE
Fix enable_scan null import drift

### DIFF
--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetOptionalBoolOmitsNullAndUnknown(t *testing.T) {
+	payload := map[string]any{}
+
+	setOptionalBool(payload, "nullBool", types.BoolNull())
+	setOptionalBool(payload, "unknownBool", types.BoolUnknown())
+
+	if _, ok := payload["nullBool"]; ok {
+		t.Fatal("null bool should be omitted from payload")
+	}
+	if _, ok := payload["unknownBool"]; ok {
+		t.Fatal("unknown bool should be omitted from payload")
+	}
+}
+
+func TestSetOptionalBoolIncludesKnownValue(t *testing.T) {
+	payload := map[string]any{}
+
+	setOptionalBool(payload, "enabled", types.BoolValue(false))
+
+	got, ok := payload["enabled"]
+	if !ok {
+		t.Fatal("known bool should be included in payload")
+	}
+	if got != false {
+		t.Fatalf("enabled: got %v, want false", got)
+	}
+}

--- a/internal/provider/resource_radarr_server.go
+++ b/internal/provider/resource_radarr_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -144,7 +145,9 @@ func (r *RadarrServerResource) Schema(_ context.Context, _ resource.SchemaReques
 			"enable_scan": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
-				Default:  booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"sync_enabled": schema.BoolAttribute{
 				Optional: true,
@@ -270,11 +273,11 @@ func (r *RadarrServerResource) payload(ctx context.Context, data RadarrServerMod
 		"minimumAvailability": data.MinimumAvailability.ValueString(),
 		"tags":                tags,
 		"isDefault":           data.IsDefault.ValueBool(),
-		"enableScan":          data.EnableScan.ValueBool(),
 		"syncEnabled":         data.SyncEnabled.ValueBool(),
 		"preventSearch":       data.PreventSearch.ValueBool(),
 		"tagRequests":         data.TagRequestsWithUser.ValueBool(),
 	}
+	setOptionalBool(base, "enableScan", data.EnableScan)
 	merged, err := mergeJSON(base, data.ExtraPayloadJSON.ValueString())
 	if err != nil {
 		return data, "", err

--- a/internal/provider/resource_sonarr_server.go
+++ b/internal/provider/resource_sonarr_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -146,7 +147,9 @@ func (r *SonarrServerResource) Schema(_ context.Context, _ resource.SchemaReques
 			"enable_scan": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
-				Default:  booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_season_folders": schema.BoolAttribute{
 				Optional: true,
@@ -297,12 +300,12 @@ func (r *SonarrServerResource) payload(ctx context.Context, data SonarrServerMod
 		"animeTags":            animeTags,
 		"is4k":                 data.Is4K.ValueBool(),
 		"isDefault":            data.IsDefault.ValueBool(),
-		"enableScan":           data.EnableScan.ValueBool(),
 		"enableSeasonFolders":  data.EnableSeasonFolders.ValueBool(),
 		"syncEnabled":          data.SyncEnabled.ValueBool(),
 		"preventSearch":        data.PreventSearch.ValueBool(),
 		"tagRequests":          data.TagRequestsWithUser.ValueBool(),
 	}
+	setOptionalBool(base, "enableScan", data.EnableScan)
 	merged, err := mergeJSON(base, data.ExtraPayloadJSON.ValueString())
 	if err != nil {
 		return data, "", err

--- a/internal/provider/server_schema_test.go
+++ b/internal/provider/server_schema_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func TestRadarrServerResourceSchemaOmitsRawJSON(t *testing.T) {
@@ -23,6 +24,31 @@ func TestSonarrServerResourceSchemaOmitsRawJSON(t *testing.T) {
 
 	if _, ok := resp.Schema.Attributes["response_json"]; ok {
 		t.Fatal("sonarr server resource should not expose response_json")
+	}
+}
+
+func TestServerResourceEnableScanPreservesUnmanagedNull(t *testing.T) {
+	tests := map[string]func(context.Context, resource.SchemaRequest, *resource.SchemaResponse){
+		"radarr": (&RadarrServerResource{}).Schema,
+		"sonarr": (&SonarrServerResource{}).Schema,
+	}
+
+	for name, buildSchema := range tests {
+		t.Run(name, func(t *testing.T) {
+			var resp resource.SchemaResponse
+			buildSchema(context.Background(), resource.SchemaRequest{}, &resp)
+
+			attr, ok := resp.Schema.Attributes["enable_scan"].(rschema.BoolAttribute)
+			if !ok {
+				t.Fatalf("enable_scan schema attribute has type %T, want BoolAttribute", resp.Schema.Attributes["enable_scan"])
+			}
+			if attr.Default != nil {
+				t.Fatal("enable_scan should not have a static default; imported API null must remain unmanaged")
+			}
+			if len(attr.PlanModifiers) == 0 {
+				t.Fatal("enable_scan should preserve prior state while unknown")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve imported/API `enableScan: null` for Radarr and Sonarr server resources when `enable_scan` is not configured
- remove the static `true` schema default and use prior state while the plan value is unknown
- omit unmanaged/null `enableScan` from server payloads so unrelated updates do not clobber live API state

## Validation
- `go test ./internal/provider`
- `go test ./...`

Closes #77