### PR TITLE
fix(issue): fail status updates when Seerr returns HTTP errors

### DIFF
--- a/internal/provider/resource_issue.go
+++ b/internal/provider/resource_issue.go
@@ -125,8 +125,7 @@ func (r *IssueResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// If status was provided as Resolved (2) in plan, update it
 	if !data.Status.IsNull() && !data.Status.IsUnknown() && data.Status.ValueInt64() == 2 {
-		_, err := r.client.Request(ctx, "POST", fmt.Sprintf("/api/v1/issue/%s/resolved", extractedID), "", nil)
-		if err != nil {
+		if err := r.applyIssueStatus(ctx, extractedID, data.Status.ValueInt64()); err != nil {
 			resp.Diagnostics.AddError("Update Status Failed", err.Error())
 			return
 		}
@@ -210,12 +209,7 @@ func (r *IssueResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	// Update status if it changed
 	if !data.Status.IsNull() && !data.Status.IsUnknown() && data.Status.ValueInt64() != state.Status.ValueInt64() {
-		statusPath := "open"
-		if data.Status.ValueInt64() == 2 {
-			statusPath = "resolved"
-		}
-		_, err := r.client.Request(ctx, "POST", fmt.Sprintf("/api/v1/issue/%s/%s", data.ID.ValueString(), statusPath), "", nil)
-		if err != nil {
+		if err := r.applyIssueStatus(ctx, data.ID.ValueString(), data.Status.ValueInt64()); err != nil {
 			resp.Diagnostics.AddError("Update Status Failed", err.Error())
 			return
 		}
@@ -228,6 +222,33 @@ func (r *IssueResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// applyIssueStatus posts a status transition to Seerr and fails on non-2xx responses.
+func (r *IssueResource) applyIssueStatus(ctx context.Context, issueID string, status int64) error {
+	statusPath, ok := issueStatusPath(status)
+	if !ok {
+		return fmt.Errorf("unsupported issue status %d; valid values are 1 (open) and 2 (resolved)", status)
+	}
+	res, err := r.client.Request(ctx, "POST", fmt.Sprintf("/api/v1/issue/%s/%s", issueID, statusPath), "", nil)
+	if err != nil {
+		return err
+	}
+	if !StatusIsOK(res.StatusCode) {
+		return fmt.Errorf("status %d: %s", res.StatusCode, string(res.Body))
+	}
+	return nil
+}
+
+func issueStatusPath(status int64) (string, bool) {
+	switch status {
+	case 1:
+		return "open", true
+	case 2:
+		return "resolved", true
+	default:
+		return "", false
+	}
 }
 
 func (r *IssueResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_issue_test.go
+++ b/internal/provider/resource_issue_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -65,5 +66,150 @@ func TestIssueReadPopulatesMediaID(t *testing.T) {
 	}
 	if got := data.MediaID.ValueInt64(); got != 550 {
 		t.Fatalf("expected media_id 550, got %d", got)
+	}
+}
+
+// Create path that resolves an issue must fail when Seerr rejects the status POST with HTTP 400.
+func TestApplyIssueStatusResolvedHTTP400(t *testing.T) {
+	var gotPath string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"cannot resolve issue"}`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := &IssueResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+
+	err = resource.applyIssueStatus(context.Background(), "11", 2)
+	if err == nil {
+		t.Fatal("expected error when POST /resolved returns 400, got nil")
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/api/v1/issue/11/resolved" {
+		t.Fatalf("expected resolved endpoint, got %s", gotPath)
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot resolve issue") {
+		t.Fatalf("expected response body in error, got %v", err)
+	}
+}
+
+// Update path that changes status to resolved must fail when Seerr returns HTTP 500.
+func TestApplyIssueStatusResolvedHTTP500(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"internal error"}`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := &IssueResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+
+	err = resource.applyIssueStatus(context.Background(), "42", 2)
+	if err == nil {
+		t.Fatal("expected error when POST /resolved returns 500, got nil")
+	}
+	if gotPath != "/api/v1/issue/42/resolved" {
+		t.Fatalf("expected resolved endpoint, got %s", gotPath)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "internal error") {
+		t.Fatalf("expected response body in error, got %v", err)
+	}
+}
+
+func TestApplyIssueStatusOpenHTTPError(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`cannot reopen`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := &IssueResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+
+	err = resource.applyIssueStatus(context.Background(), "7", 1)
+	if err == nil {
+		t.Fatal("expected error when POST /open returns 400, got nil")
+	}
+	if gotPath != "/api/v1/issue/7/open" {
+		t.Fatalf("expected open endpoint, got %s", gotPath)
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+}
+
+func TestApplyIssueStatusOK(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":2}`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := &IssueResource{
+		client: NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout),
+	}
+	if err := resource.applyIssueStatus(context.Background(), "9", 2); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/api/v1/issue/9/resolved" {
+		t.Fatalf("expected resolved endpoint, got %s", gotPath)
+	}
+}
+
+func TestIssueStatusPath(t *testing.T) {
+	tests := map[int64]string{
+		1: "open",
+		2: "resolved",
+	}
+	for status, want := range tests {
+		got, ok := issueStatusPath(status)
+		if !ok || got != want {
+			t.Fatalf("issueStatusPath(%d) = %q, %v; want %q, true", status, got, ok, want)
+		}
+	}
+	if _, ok := issueStatusPath(99); ok {
+		t.Fatal("expected unknown status to be rejected")
 	}
 }


### PR DESCRIPTION
## Summary
Issue status transitions on Create (resolved path) and Update only checked transport errors from `client.Request`, not HTTP status. A 4xx/5xx from Seerr could be ignored and Terraform could still record a rejected status.

## Changes
- Extract `applyIssueStatus` helper (mirrors `applyRequestStatus`) that POSTs `/open` or `/resolved` and requires `StatusIsOK`
- On failure, returns an error with status code + body so Create/Update add diagnostics and do not set success state
- Wire Create resolved path and Update status change through the helper

## Tests
- `TestApplyIssueStatusResolvedHTTP400` — Create-style resolve path surfaces 400 + body
- `TestApplyIssueStatusResolvedHTTP500` — Update-style resolve path surfaces 500 + body
- `TestApplyIssueStatusOpenHTTPError` — open path also fails on non-2xx
- `TestApplyIssueStatusOK` / `TestIssueStatusPath` — happy path + path mapping

```
go test ./internal/provider/ -count=1
```

Closes #83