### PR TITLE
Add reusable pagination for collection data sources

### DIFF
--- a/internal/provider/data_source_issues.go
+++ b/internal/provider/data_source_issues.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -92,26 +91,13 @@ func (d *IssuesDataSource) Configure(_ context.Context, req datasource.Configure
 func (d *IssuesDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data IssuesDataSourceModel
 
-	// Fetch issues
-	res, err := d.client.Request(ctx, "GET", "/api/v1/issue?take=1000", "", nil)
+	results, err := fetchAllPaginatedResults(ctx, d.client, "/api/v1/issue", defaultPaginationPageSize)
 	if err != nil {
 		resp.Diagnostics.AddError("Read Failed", err.Error())
 		return
 	}
-	if !StatusIsOK(res.StatusCode) {
-		resp.Diagnostics.AddError("Read Failed", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
-		return
-	}
 
-	var parsedResponse struct {
-		Results []map[string]any `json:"results"`
-	}
-	if err := json.Unmarshal(res.Body, &parsedResponse); err != nil {
-		resp.Diagnostics.AddError("Read Failed", "Failed to parse API response: "+err.Error())
-		return
-	}
-
-	for _, u := range parsedResponse.Results {
+	for _, u := range results {
 		issue := IssueSummaryModel{}
 
 		idRaw := u["id"]

--- a/internal/provider/data_source_requests.go
+++ b/internal/provider/data_source_requests.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -87,26 +86,13 @@ func (d *RequestsDataSource) Configure(_ context.Context, req datasource.Configu
 func (d *RequestsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data RequestsDataSourceModel
 
-	// Fetch requests
-	res, err := d.client.Request(ctx, "GET", "/api/v1/request?take=1000", "", nil)
+	results, err := fetchAllPaginatedResults(ctx, d.client, "/api/v1/request", defaultPaginationPageSize)
 	if err != nil {
 		resp.Diagnostics.AddError("Read Failed", err.Error())
 		return
 	}
-	if !StatusIsOK(res.StatusCode) {
-		resp.Diagnostics.AddError("Read Failed", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
-		return
-	}
 
-	var parsedResponse struct {
-		Results []map[string]any `json:"results"`
-	}
-	if err := json.Unmarshal(res.Body, &parsedResponse); err != nil {
-		resp.Diagnostics.AddError("Read Failed", "Failed to parse API response: "+err.Error())
-		return
-	}
-
-	for _, u := range parsedResponse.Results {
+	for _, u := range results {
 		request := RequestSummaryModel{}
 
 		idRaw := u["id"]

--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -97,30 +96,17 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		searchUsername = strings.ToLower(data.Username.ValueString())
 	}
 
-	// Fetch users (Seerr API doesn't support server-side filtering, so we fetch and filter client-side)
-	// We'll fetch up to 1000 users. If a server has more, this might need pagination logic, but 1000 is a safe upper bound for a typical homelab.
-	res, err := d.client.Request(ctx, "GET", "/api/v1/user?take=1000", "", nil)
+	// Seerr API doesn't support server-side filtering; fetch all users (paginated) and filter client-side.
+	results, err := fetchAllPaginatedResults(ctx, d.client, "/api/v1/user", defaultPaginationPageSize)
 	if err != nil {
 		resp.Diagnostics.AddError("Read Failed", err.Error())
-		return
-	}
-	if !StatusIsOK(res.StatusCode) {
-		resp.Diagnostics.AddError("Read Failed", fmt.Sprintf("status %d: %s", res.StatusCode, string(res.Body)))
-		return
-	}
-
-	var parsedResponse struct {
-		Results []map[string]any `json:"results"`
-	}
-	if err := json.Unmarshal(res.Body, &parsedResponse); err != nil {
-		resp.Diagnostics.AddError("Read Failed", "Failed to parse API response: "+err.Error())
 		return
 	}
 
 	var matchedUser map[string]any
 	matchCount := 0
 
-	for _, u := range parsedResponse.Results {
+	for _, u := range results {
 		if searchEmail != "" {
 			if e, ok := u["email"].(string); ok && strings.ToLower(e) == searchEmail {
 				matchedUser = u

--- a/internal/provider/data_source_users.go
+++ b/internal/provider/data_source_users.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -88,25 +87,27 @@ func (d *UsersDataSource) Configure(_ context.Context, req datasource.ConfigureR
 func (d *UsersDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data UsersDataSourceModel
 
-	// Fetch users
-	res, err := d.client.Request(ctx, "GET", "/api/v1/user?take=1000", "", nil)
+	users, err := d.fetchUsers(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Read Failed", err.Error())
 		return
 	}
-	if !HandleAPIResponse(ctx, res, &resp.Diagnostics, "Read") {
-		return
+
+	data.Users = users
+	data.ID = types.StringValue("all_users")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// fetchUsers retrieves every user page from the Seerr API.
+func (d *UsersDataSource) fetchUsers(ctx context.Context) ([]UserSummaryModel, error) {
+	results, err := fetchAllPaginatedResults(ctx, d.client, "/api/v1/user", defaultPaginationPageSize)
+	if err != nil {
+		return nil, err
 	}
 
-	var parsedResponse struct {
-		Results []map[string]any `json:"results"`
-	}
-	if err := json.Unmarshal(res.Body, &parsedResponse); err != nil {
-		resp.Diagnostics.AddError("Read Failed", "Failed to parse API response: "+err.Error())
-		return
-	}
-
-	for _, u := range parsedResponse.Results {
+	users := make([]UserSummaryModel, 0, len(results))
+	for _, u := range results {
 		user := UserSummaryModel{}
 
 		idRaw := u["id"]
@@ -131,10 +132,7 @@ func (d *UsersDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 			}
 		}
 
-		data.Users = append(data.Users, user)
+		users = append(users, user)
 	}
-
-	data.ID = types.StringValue("all_users")
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	return users, nil
 }

--- a/internal/provider/pagination.go
+++ b/internal/provider/pagination.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// defaultPaginationPageSize is used when auto-fetching all pages from Seerr list endpoints.
+// Prefer a moderate size over a large hard-coded take so servers are not overloaded.
+const defaultPaginationPageSize = 100
+
+// fetchAllPaginatedResults loads every page from a Seerr list endpoint that returns
+// { "results": [...], "pageInfo": { "pages", "page", "pageSize", "results", "total" } }.
+//
+// basePath may include an existing query string (e.g. /api/v1/issue?filter=open); take and
+// skip are set/overwritten for each page. When pageSize <= 0, defaultPaginationPageSize is used.
+func fetchAllPaginatedResults(ctx context.Context, client *APIClient, basePath string, pageSize int) ([]map[string]any, error) {
+	if client == nil {
+		return nil, fmt.Errorf("API client is nil")
+	}
+	if pageSize <= 0 {
+		pageSize = defaultPaginationPageSize
+	}
+
+	pathOnly, query, err := splitPathQuery(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var all []map[string]any
+	skip := 0
+
+	for {
+		pageQuery := cloneURLValues(query)
+		pageQuery.Set("take", strconv.Itoa(pageSize))
+		pageQuery.Set("skip", strconv.Itoa(skip))
+
+		endpoint := pathOnly
+		if encoded := pageQuery.Encode(); encoded != "" {
+			endpoint += "?" + encoded
+		}
+
+		res, err := client.Request(ctx, "GET", endpoint, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		if !StatusIsOK(res.StatusCode) {
+			return nil, fmt.Errorf("status %d: %s", res.StatusCode, string(res.Body))
+		}
+
+		pageResults, pageInfo, err := parsePaginatedResponse(res.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(pageResults) == 0 {
+			break
+		}
+
+		all = append(all, pageResults...)
+
+		// Stop when we know we are on the last page, when the page is short of pageSize,
+		// or when we have accumulated the reported total.
+		if shouldStopPagination(pageInfo, len(pageResults), pageSize, len(all)) {
+			break
+		}
+
+		// Advance skip by the number of results returned (equivalent to pageSize when full).
+		skip = len(all)
+	}
+
+	return all, nil
+}
+
+type pageInfo struct {
+	pages    int
+	page     int
+	pageSize int
+	results  int
+	total    int
+	hasPages bool
+	hasPage  bool
+	hasTotal bool
+}
+
+func parsePaginatedResponse(body []byte) ([]map[string]any, pageInfo, error) {
+	var payload struct {
+		Results  []map[string]any `json:"results"`
+		PageInfo json.RawMessage  `json:"pageInfo"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, pageInfo{}, fmt.Errorf("failed to parse paginated response: %w", err)
+	}
+
+	info := pageInfo{}
+	if len(payload.PageInfo) > 0 && string(payload.PageInfo) != "null" {
+		var raw map[string]any
+		if err := json.Unmarshal(payload.PageInfo, &raw); err != nil {
+			return nil, pageInfo{}, fmt.Errorf("failed to parse pageInfo: %w", err)
+		}
+		if v, ok := int64ValueFromAny(raw["pages"]); ok {
+			info.pages = int(v)
+			info.hasPages = true
+		}
+		if v, ok := int64ValueFromAny(raw["page"]); ok {
+			info.page = int(v)
+			info.hasPage = true
+		}
+		if v, ok := int64ValueFromAny(raw["pageSize"]); ok {
+			info.pageSize = int(v)
+		}
+		if v, ok := int64ValueFromAny(raw["results"]); ok {
+			info.results = int(v)
+		}
+		if v, ok := int64ValueFromAny(raw["total"]); ok {
+			info.total = int(v)
+			info.hasTotal = true
+		}
+	}
+
+	if payload.Results == nil {
+		payload.Results = []map[string]any{}
+	}
+	return payload.Results, info, nil
+}
+
+func shouldStopPagination(info pageInfo, pageLen, pageSize, totalFetched int) bool {
+	if pageLen == 0 {
+		return true
+	}
+	// Short page means no further results under take/skip semantics.
+	if pageLen < pageSize {
+		return true
+	}
+	if info.hasPage && info.hasPages && info.page > 0 && info.pages > 0 && info.page >= info.pages {
+		return true
+	}
+	if info.hasTotal && info.total >= 0 && totalFetched >= info.total {
+		return true
+	}
+	return false
+}
+
+func splitPathQuery(basePath string) (string, url.Values, error) {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" {
+		return "", nil, fmt.Errorf("base path is empty")
+	}
+
+	// Use url.Parse so relative paths with queries work.
+	u, err := url.Parse(basePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid base path %q: %w", basePath, err)
+	}
+
+	pathOnly := u.Path
+	if pathOnly == "" {
+		if i := strings.Index(basePath, "?"); i >= 0 {
+			pathOnly = basePath[:i]
+		} else {
+			pathOnly = basePath
+		}
+	}
+
+	query := url.Values{}
+	for k, vs := range u.Query() {
+		for _, v := range vs {
+			query.Add(k, v)
+		}
+	}
+	return pathOnly, query, nil
+}
+
+func cloneURLValues(in url.Values) url.Values {
+	out := make(url.Values, len(in))
+	for k, vs := range in {
+		cp := make([]string, len(vs))
+		copy(cp, vs)
+		out[k] = cp
+	}
+	return out
+}

--- a/internal/provider/pagination.go
+++ b/internal/provider/pagination.go
@@ -49,7 +49,7 @@ func fetchAllPaginatedResults(ctx context.Context, client *APIClient, basePath s
 			return nil, err
 		}
 		if !StatusIsOK(res.StatusCode) {
-			return nil, fmt.Errorf("status %d: %s", res.StatusCode, string(res.Body))
+			return nil, fmt.Errorf("status %d: %s", res.StatusCode, formatAPIErrorBody(res.Body))
 		}
 
 		pageResults, pageInfo, err := parsePaginatedResponse(res.Body)
@@ -97,7 +97,8 @@ func parsePaginatedResponse(body []byte) ([]map[string]any, pageInfo, error) {
 	}
 
 	info := pageInfo{}
-	if len(payload.PageInfo) > 0 && string(payload.PageInfo) != "null" {
+	pageInfoRaw := strings.TrimSpace(string(payload.PageInfo))
+	if len(payload.PageInfo) > 0 && pageInfoRaw != "" && pageInfoRaw != "null" {
 		var raw map[string]any
 		if err := json.Unmarshal(payload.PageInfo, &raw); err != nil {
 			return nil, pageInfo{}, fmt.Errorf("failed to parse pageInfo: %w", err)
@@ -132,17 +133,45 @@ func shouldStopPagination(info pageInfo, pageLen, pageSize, totalFetched int) bo
 	if pageLen == 0 {
 		return true
 	}
-	// Short page means no further results under take/skip semantics.
-	if pageLen < pageSize {
-		return true
-	}
-	if info.hasPage && info.hasPages && info.page > 0 && info.pages > 0 && info.page >= info.pages {
-		return true
+	// Prefer server pagination metadata when present.
+	if info.hasPage && info.hasPages && info.page > 0 && info.pages > 0 {
+		if info.page >= info.pages {
+			return true
+		}
+		// Metadata says more pages exist; do not stop on a short page alone
+		// (servers may cap page size below the requested take).
+		if info.hasTotal && info.total >= 0 && totalFetched >= info.total {
+			return true
+		}
+		return false
 	}
 	if info.hasTotal && info.total >= 0 && totalFetched >= info.total {
 		return true
 	}
+	// Short-page heuristic only when no usable pageInfo metadata is available.
+	if pageLen < pageSize {
+		return true
+	}
 	return false
+}
+
+// formatAPIErrorBody extracts message/error from a JSON API body when present,
+// matching HandleAPIResponse diagnostics style.
+func formatAPIErrorBody(body []byte) string {
+	errorMsg := string(body)
+	var errBody struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errBody); err == nil {
+		if errBody.Message != "" {
+			return errBody.Message
+		}
+		if errBody.Error != "" {
+			return errBody.Error
+		}
+	}
+	return errorMsg
 }
 
 func splitPathQuery(basePath string) (string, url.Values, error) {

--- a/internal/provider/pagination_test.go
+++ b/internal/provider/pagination_test.go
@@ -175,6 +175,50 @@ func TestFetchAllPaginatedResultsHTTPError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on non-OK status")
 	}
+	if err.Error() != "status 500: boom" {
+		t.Fatalf("expected extracted message in error, got %v", err)
+	}
+}
+
+func TestParsePaginatedResponsePageInfoNullWithWhitespace(t *testing.T) {
+	results, info, err := parsePaginatedResponse([]byte(`{"results":[{"id":1}],"pageInfo": null
+}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if info.hasPages || info.hasPage || info.hasTotal {
+		t.Fatalf("expected empty pageInfo for null, got %+v", info)
+	}
+}
+
+func TestShouldStopPaginationShortPageWithMetadataContinues(t *testing.T) {
+	// Server capped page size below requested take, but pageInfo says more pages remain.
+	info := pageInfo{page: 1, pages: 3, hasPage: true, hasPages: true, total: 30, hasTotal: true}
+	if shouldStopPagination(info, 10, 100, 10) {
+		t.Fatal("expected short page not to stop when pageInfo indicates more pages")
+	}
+	if !shouldStopPagination(info, 10, 100, 30) {
+		t.Fatal("expected stop when totalFetched reaches total")
+	}
+	// Without metadata, short page is a stop signal.
+	if !shouldStopPagination(pageInfo{}, 10, 100, 10) {
+		t.Fatal("expected short page to stop when pageInfo is absent")
+	}
+}
+
+func TestFormatAPIErrorBody(t *testing.T) {
+	if got := formatAPIErrorBody([]byte(`{"message":"nope"}`)); got != "nope" {
+		t.Fatalf("message field: got %q", got)
+	}
+	if got := formatAPIErrorBody([]byte(`{"error":"bad"}`)); got != "bad" {
+		t.Fatalf("error field: got %q", got)
+	}
+	if got := formatAPIErrorBody([]byte(`plain`)); got != "plain" {
+		t.Fatalf("plain body: got %q", got)
+	}
 }
 
 // TestUsersDataSourceReadAggregatesMultiplePages is an integration-style unit test that

--- a/internal/provider/pagination_test.go
+++ b/internal/provider/pagination_test.go
@@ -1,0 +1,286 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+func TestFetchAllPaginatedResultsAggregatesPages(t *testing.T) {
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/user" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+
+		take := r.URL.Query().Get("take")
+		skip := r.URL.Query().Get("skip")
+		calls = append(calls, fmt.Sprintf("take=%s&skip=%s", take, skip))
+
+		w.Header().Set("Content-Type", "application/json")
+		switch skip {
+		case "0":
+			_, _ = w.Write([]byte(`{
+				"results":[{"id":1,"email":"a@example.com"},{"id":2,"email":"b@example.com"}],
+				"pageInfo":{"pages":2,"page":1,"pageSize":2,"results":2,"total":3}
+			}`))
+		case "2":
+			_, _ = w.Write([]byte(`{
+				"results":[{"id":3,"email":"c@example.com"}],
+				"pageInfo":{"pages":2,"page":2,"pageSize":2,"results":1,"total":3}
+			}`))
+		default:
+			_, _ = w.Write([]byte(`{
+				"results":[],
+				"pageInfo":{"pages":2,"page":3,"pageSize":2,"results":0,"total":3}
+			}`))
+		}
+	}))
+	defer srv.Close()
+
+	client := testPaginationClient(t, srv.URL)
+
+	results, err := fetchAllPaginatedResults(context.Background(), client, "/api/v1/user", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := len(results), 3; got != want {
+		t.Fatalf("expected %d aggregated results, got %d", want, got)
+	}
+	if got, want := intFromAny(results[0]["id"]), 1; got != want {
+		t.Fatalf("first result id: got %d, want %d", got, want)
+	}
+	if got, want := intFromAny(results[2]["id"]), 3; got != want {
+		t.Fatalf("third result id: got %d, want %d", got, want)
+	}
+	if got, want := results[2]["email"], "c@example.com"; got != want {
+		t.Fatalf("third result email: got %v, want %v", got, want)
+	}
+
+	// Should stop after last non-empty page (page 2 of 2), not request empty page 3.
+	if got, want := len(calls), 2; got != want {
+		t.Fatalf("expected %d API calls, got %d (%v)", want, got, calls)
+	}
+	if calls[0] != "take=2&skip=0" {
+		t.Fatalf("first call query: got %q, want take=2&skip=0", calls[0])
+	}
+	if calls[1] != "take=2&skip=2" {
+		t.Fatalf("second call query: got %q, want take=2&skip=2", calls[1])
+	}
+}
+
+func TestFetchAllPaginatedResultsStopsOnEmptyResults(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		skip, _ := strconv.Atoi(r.URL.Query().Get("skip"))
+		w.Header().Set("Content-Type", "application/json")
+		if skip == 0 {
+			_, _ = w.Write([]byte(`{
+				"results":[{"id":10},{"id":11}],
+				"pageInfo":{"pages":99,"page":1,"pageSize":2,"results":2,"total":100}
+			}`))
+			return
+		}
+		// Empty page even if pageInfo claims more pages.
+		_, _ = w.Write([]byte(`{"results":[],"pageInfo":{"pages":99,"page":2,"pageSize":2,"results":0,"total":100}}`))
+	}))
+	defer srv.Close()
+
+	client := testPaginationClient(t, srv.URL)
+
+	results, err := fetchAllPaginatedResults(context.Background(), client, "/api/v1/request", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := len(results), 2; got != want {
+		t.Fatalf("expected %d results, got %d", want, got)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 calls (one full page + empty), got %d", callCount)
+	}
+}
+
+func TestFetchAllPaginatedResultsPreservesExistingQuery(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":1}],"pageInfo":{"pages":1,"page":1,"pageSize":10,"results":1,"total":1}}`))
+	}))
+	defer srv.Close()
+
+	client := testPaginationClient(t, srv.URL)
+
+	results, err := fetchAllPaginatedResults(context.Background(), client, "/api/v1/issue?filter=open&sort=added", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if gotQuery.Get("filter") != "open" {
+		t.Fatalf("expected preserved filter=open, got %q", gotQuery.Get("filter"))
+	}
+	if gotQuery.Get("sort") != "added" {
+		t.Fatalf("expected preserved sort=added, got %q", gotQuery.Get("sort"))
+	}
+	if gotQuery.Get("take") != "10" {
+		t.Fatalf("expected take=10, got %q", gotQuery.Get("take"))
+	}
+	if gotQuery.Get("skip") != "0" {
+		t.Fatalf("expected skip=0, got %q", gotQuery.Get("skip"))
+	}
+}
+
+func TestFetchAllPaginatedResultsDefaultPageSize(t *testing.T) {
+	var take string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		take = r.URL.Query().Get("take")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[],"pageInfo":{"pages":0,"page":1,"pageSize":100,"results":0,"total":0}}`))
+	}))
+	defer srv.Close()
+
+	client := testPaginationClient(t, srv.URL)
+
+	_, err := fetchAllPaginatedResults(context.Background(), client, "/api/v1/user", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if take != strconv.Itoa(defaultPaginationPageSize) {
+		t.Fatalf("expected default take=%d, got %q", defaultPaginationPageSize, take)
+	}
+}
+
+func TestFetchAllPaginatedResultsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer srv.Close()
+
+	client := testPaginationClient(t, srv.URL)
+
+	_, err := fetchAllPaginatedResults(context.Background(), client, "/api/v1/user", 100)
+	if err == nil {
+		t.Fatal("expected error on non-OK status")
+	}
+}
+
+// TestUsersDataSourceReadAggregatesMultiplePages is an integration-style unit test that
+// exercises the users collection data source against a multi-page mock API.
+func TestUsersDataSourceReadAggregatesMultiplePages(t *testing.T) {
+	const totalUsers = 150
+
+	all := make([]map[string]any, 0, totalUsers)
+	for i := 1; i <= totalUsers; i++ {
+		all = append(all, map[string]any{
+			"id":          i,
+			"email":       fmt.Sprintf("user%d@example.com", i),
+			"username":    fmt.Sprintf("user%d", i),
+			"permissions": i % 8,
+		})
+	}
+
+	var callSkips []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/user" {
+			http.NotFound(w, r)
+			return
+		}
+		take, _ := strconv.Atoi(r.URL.Query().Get("take"))
+		skip, _ := strconv.Atoi(r.URL.Query().Get("skip"))
+		callSkips = append(callSkips, skip)
+		if take != defaultPaginationPageSize {
+			t.Errorf("expected take=%d, got %d", defaultPaginationPageSize, take)
+		}
+
+		start := skip
+		if start > len(all) {
+			start = len(all)
+		}
+		end := start + take
+		if end > len(all) {
+			end = len(all)
+		}
+		pageResults := all[start:end]
+		totalPages := (len(all) + take - 1) / take
+		pageNum := 1
+		if take > 0 {
+			pageNum = (skip / take) + 1
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": pageResults,
+			"pageInfo": map[string]any{
+				"pages":    totalPages,
+				"page":     pageNum,
+				"pageSize": take,
+				"results":  len(pageResults),
+				"total":    len(all),
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ds := &UsersDataSource{client: testPaginationClient(t, srv.URL)}
+	users, err := ds.fetchUsers(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := len(users), totalUsers; got != want {
+		t.Fatalf("expected %d users aggregated, got %d", want, got)
+	}
+	if len(callSkips) < 2 {
+		t.Fatalf("expected multi-page fetches, got skips %v", callSkips)
+	}
+	if callSkips[0] != 0 || callSkips[1] != defaultPaginationPageSize {
+		t.Fatalf("unexpected skip sequence %v", callSkips)
+	}
+	if got := users[0].ID.ValueString(); got != "1" {
+		t.Fatalf("first user id: got %q want 1", got)
+	}
+	if got := users[totalUsers-1].ID.ValueString(); got != "150" {
+		t.Fatalf("last user id: got %q want 150", got)
+	}
+	if got := users[totalUsers-1].Email.ValueString(); got != "user150@example.com" {
+		t.Fatalf("last user email: got %q", got)
+	}
+}
+
+func testPaginationClient(t *testing.T, rawURL string) *APIClient {
+	t.Helper()
+	baseURL, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout)
+}
+
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return -1
+	}
+}


### PR DESCRIPTION
## Summary
Collection data sources previously hard-coded `take=1000`, which silently omitted records on larger Seerr installs.

This PR adds a shared `fetchAllPaginatedResults` helper that walks Seerr `{ results, pageInfo }` list endpoints with `take`/`skip` until all pages are loaded (default page size 100), and wires it into:

- `seerr_users`
- `seerr_requests`
- `seerr_issues`
- `seerr_user` (client-side lookup list fetch)

## Tests
- Unit tests for multi-page aggregation, empty-page stop, query preservation, default page size, and HTTP errors
- Integration-style multi-page mock for users data source (`fetchUsers`)
- `go test ./internal/provider/ -count=1` passes

Closes #79