### PR TITLE
feat(request): poll async status after create/update

### DIFF
--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -35,6 +35,8 @@ resource "seerr_request" "example" {
 - `seasons` (List of Number) List of season numbers to request (TV only).
 - `server_id` (Number) Override the server ID for the request.
 - `status` (Number) The desired status of the request (1: Pending, 2: Approved, 3: Declined).
+- `status_wait_interval_seconds` (Number) Seconds between status polls when status_wait_timeout_seconds is greater than 0. Defaults to 2; minimum 1.
+- `status_wait_timeout_seconds` (Number) Maximum seconds to wait after applying desired status for the observed request status to match. Defaults to 0 (waiting disabled).
 - `user_id` (Number) The ID of the user making the request (defaults to current user).
 
 ### Read-Only

--- a/internal/provider/resource_request.go
+++ b/internal/provider/resource_request.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -12,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -27,17 +30,19 @@ type RequestResource struct {
 }
 
 type RequestModel struct {
-	ID           types.String `tfsdk:"id"`
-	MediaType    types.String `tfsdk:"media_type"`
-	MediaID      types.Int64  `tfsdk:"media_id"`
-	SeerrMediaID types.Int64  `tfsdk:"seerr_media_id"`
-	Seasons      types.List   `tfsdk:"seasons"`
-	Is4K         types.Bool   `tfsdk:"is_4k"`
-	ServerID     types.Int64  `tfsdk:"server_id"`
-	ProfileID    types.Int64  `tfsdk:"profile_id"`
-	RootFolder   types.String `tfsdk:"root_folder"`
-	UserID       types.Int64  `tfsdk:"user_id"`
-	Status       types.Int64  `tfsdk:"status"`
+	ID                        types.String `tfsdk:"id"`
+	MediaType                 types.String `tfsdk:"media_type"`
+	MediaID                   types.Int64  `tfsdk:"media_id"`
+	SeerrMediaID              types.Int64  `tfsdk:"seerr_media_id"`
+	Seasons                   types.List   `tfsdk:"seasons"`
+	Is4K                      types.Bool   `tfsdk:"is_4k"`
+	ServerID                  types.Int64  `tfsdk:"server_id"`
+	ProfileID                 types.Int64  `tfsdk:"profile_id"`
+	RootFolder                types.String `tfsdk:"root_folder"`
+	UserID                    types.Int64  `tfsdk:"user_id"`
+	Status                    types.Int64  `tfsdk:"status"`
+	StatusWaitTimeoutSeconds  types.Int64  `tfsdk:"status_wait_timeout_seconds"`
+	StatusWaitIntervalSeconds types.Int64  `tfsdk:"status_wait_interval_seconds"`
 }
 
 func NewRequestResource() resource.Resource {
@@ -124,6 +129,24 @@ func (r *RequestResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					int64validator.OneOf(1, 2, 3),
 				},
 			},
+			"status_wait_timeout_seconds": schema.Int64Attribute{
+				MarkdownDescription: "Maximum seconds to wait after applying desired status for the observed request status to match. Defaults to 0 (waiting disabled).",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(0),
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+			"status_wait_interval_seconds": schema.Int64Attribute{
+				MarkdownDescription: "Seconds between status polls when status_wait_timeout_seconds is greater than 0. Defaults to 2; minimum 1.",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(2),
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
+			},
 		},
 	}
 }
@@ -202,6 +225,10 @@ func (r *RequestResource) Create(ctx context.Context, req resource.CreateRequest
 
 	if err := r.applyRequestStatus(ctx, extractedID, desiredStatus); err != nil {
 		resp.Diagnostics.AddError("Update Status Failed", err.Error())
+		return
+	}
+	if err := r.waitForDesiredRequestStatus(ctx, extractedID, desiredStatus, data); err != nil {
+		resp.Diagnostics.AddError("Wait For Request Status Failed", err.Error())
 		return
 	}
 	diags = r.readRequest(ctx, extractedID, &data)
@@ -316,6 +343,10 @@ func (r *RequestResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Update Status Failed", err.Error())
 		return
 	}
+	if err := r.waitForDesiredRequestStatus(ctx, data.ID.ValueString(), data.Status, data); err != nil {
+		resp.Diagnostics.AddError("Wait For Request Status Failed", err.Error())
+		return
+	}
 
 	diags := r.readRequest(ctx, data.ID.ValueString(), &data)
 	resp.Diagnostics.Append(diags...)
@@ -363,6 +394,106 @@ func (r *RequestResource) applyRequestStatus(ctx context.Context, requestID stri
 		return fmt.Errorf("status %d: %s", res.StatusCode, string(res.Body))
 	}
 	return nil
+}
+
+func (r *RequestResource) waitForDesiredRequestStatus(ctx context.Context, requestID string, status types.Int64, data RequestModel) error {
+	if status.IsNull() || status.IsUnknown() {
+		return nil
+	}
+	timeoutSeconds := int64(0)
+	if !data.StatusWaitTimeoutSeconds.IsNull() && !data.StatusWaitTimeoutSeconds.IsUnknown() {
+		timeoutSeconds = data.StatusWaitTimeoutSeconds.ValueInt64()
+	}
+	if timeoutSeconds <= 0 {
+		return nil
+	}
+
+	intervalSeconds := int64(2)
+	if !data.StatusWaitIntervalSeconds.IsNull() && !data.StatusWaitIntervalSeconds.IsUnknown() {
+		intervalSeconds = data.StatusWaitIntervalSeconds.ValueInt64()
+	}
+	if intervalSeconds < 1 {
+		intervalSeconds = 1
+	}
+
+	return waitForRequestStatus(
+		ctx,
+		r.client,
+		requestID,
+		status.ValueInt64(),
+		time.Duration(timeoutSeconds)*time.Second,
+		time.Duration(intervalSeconds)*time.Second,
+		nil,
+	)
+}
+
+// waitForRequestStatus polls GET /api/v1/request/{id} until the observed status
+// matches wantStatus, the timeout elapses, or ctx is cancelled.
+// sleep may be nil to use a context-aware default sleep (injectable for tests).
+func waitForRequestStatus(ctx context.Context, client *APIClient, requestID string, wantStatus int64, timeout, interval time.Duration, sleep func(context.Context, time.Duration) error) error {
+	if sleep == nil {
+		sleep = sleepContext
+	}
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+	var lastStatus int64 = -1
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("waiting for request %s status %d: %w", requestID, wantStatus, err)
+		}
+
+		res, err := client.Request(ctx, "GET", "/api/v1/request/"+requestID, "", nil)
+		if err != nil {
+			return fmt.Errorf("waiting for request %s status: %w", requestID, err)
+		}
+		if !StatusIsOK(res.StatusCode) {
+			return fmt.Errorf("waiting for request %s status: status %d: %s", requestID, res.StatusCode, string(res.Body))
+		}
+
+		var m map[string]any
+		if err := json.Unmarshal(res.Body, &m); err != nil {
+			return fmt.Errorf("waiting for request %s status: parse response: %w", requestID, err)
+		}
+		statusVal, ok := m["status"].(float64)
+		if !ok {
+			return fmt.Errorf("waiting for request %s status: response missing numeric status field", requestID)
+		}
+		lastStatus = int64(statusVal)
+		if lastStatus == wantStatus {
+			return nil
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("timed out after %s waiting for request %s to reach status %d (last observed %d)", timeout, requestID, wantStatus, lastStatus)
+		}
+
+		sleepFor := interval
+		if remaining < sleepFor {
+			sleepFor = remaining
+		}
+		if err := sleep(ctx, sleepFor); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("waiting for request %s status %d: %w", requestID, wantStatus, err)
+			}
+			return err
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func requestStatusPath(status int64) (string, bool) {

--- a/internal/provider/resource_request.go
+++ b/internal/provider/resource_request.go
@@ -430,6 +430,9 @@ func (r *RequestResource) waitForDesiredRequestStatus(ctx context.Context, reque
 // waitForRequestStatus polls GET /api/v1/request/{id} until the observed status
 // matches wantStatus, the timeout elapses, or ctx is cancelled.
 // sleep may be nil to use a context-aware default sleep (injectable for tests).
+//
+// The wait timeout is applied as a context deadline so individual HTTP GETs cannot
+// outlive status_wait_timeout_seconds when the HTTP client timeout is larger.
 func waitForRequestStatus(ctx context.Context, client *APIClient, requestID string, wantStatus int64, timeout, interval time.Duration, sleep func(context.Context, time.Duration) error) error {
 	if sleep == nil {
 		sleep = sleepContext
@@ -437,17 +440,32 @@ func waitForRequestStatus(ctx context.Context, client *APIClient, requestID stri
 	if interval <= 0 {
 		interval = 2 * time.Second
 	}
+	if timeout <= 0 {
+		return nil
+	}
 
 	deadline := time.Now().Add(timeout)
+	waitCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
 	var lastStatus int64 = -1
 
 	for {
-		if err := ctx.Err(); err != nil {
+		if err := waitCtx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("timed out after %s waiting for request %s to reach status %d (last observed %d)", timeout, requestID, wantStatus, lastStatus)
+			}
 			return fmt.Errorf("waiting for request %s status %d: %w", requestID, wantStatus, err)
 		}
 
-		res, err := client.Request(ctx, "GET", "/api/v1/request/"+requestID, "", nil)
+		res, err := client.Request(waitCtx, "GET", "/api/v1/request/"+requestID, "", nil)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || waitCtx.Err() != nil && errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("timed out after %s waiting for request %s to reach status %d (last observed %d)", timeout, requestID, wantStatus, lastStatus)
+			}
+			if errors.Is(err, context.Canceled) || waitCtx.Err() != nil && errors.Is(waitCtx.Err(), context.Canceled) {
+				return fmt.Errorf("waiting for request %s status %d: %w", requestID, wantStatus, context.Canceled)
+			}
 			return fmt.Errorf("waiting for request %s status: %w", requestID, err)
 		}
 		if !StatusIsOK(res.StatusCode) {
@@ -476,8 +494,11 @@ func waitForRequestStatus(ctx context.Context, client *APIClient, requestID stri
 		if remaining < sleepFor {
 			sleepFor = remaining
 		}
-		if err := sleep(ctx, sleepFor); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if err := sleep(waitCtx, sleepFor); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("timed out after %s waiting for request %s to reach status %d (last observed %d)", timeout, requestID, wantStatus, lastStatus)
+			}
+			if errors.Is(err, context.Canceled) {
 				return fmt.Errorf("waiting for request %s status %d: %w", requestID, wantStatus, err)
 			}
 			return err

--- a/internal/provider/resource_request_test.go
+++ b/internal/provider/resource_request_test.go
@@ -3,10 +3,13 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -125,5 +128,122 @@ func TestRequestStatusPath(t *testing.T) {
 	}
 	if _, ok := requestStatusPath(99); ok {
 		t.Fatal("expected unknown status to be rejected")
+	}
+}
+
+func TestWaitForRequestStatusSuccess(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/request/42" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		calls++
+		status := 1
+		if calls >= 2 {
+			status = 2
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": status})
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout)
+
+	sleepCalls := 0
+	err = waitForRequestStatus(
+		context.Background(),
+		client,
+		"42",
+		2,
+		5*time.Second,
+		time.Second,
+		func(ctx context.Context, d time.Duration) error {
+			sleepCalls++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if calls < 2 {
+		t.Fatalf("expected at least 2 GETs, got %d", calls)
+	}
+	if sleepCalls < 1 {
+		t.Fatalf("expected at least one sleep between polls, got %d", sleepCalls)
+	}
+}
+
+func TestWaitForRequestStatusTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": 1})
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout)
+
+	// No-op sleep: deadline uses wall clock with a short timeout so the test stays fast.
+	err = waitForRequestStatus(
+		context.Background(),
+		client,
+		"42",
+		2,
+		50*time.Millisecond,
+		time.Millisecond,
+		func(ctx context.Context, d time.Duration) error {
+			return nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout") && !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout-related error, got %v", err)
+	}
+}
+
+func TestWaitForRequestStatusContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": 1})
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(baseURL, "abc123", "test-agent", false, defaultRequestTimeout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel during the first sleep so the helper must honor ctx.Done().
+	err = waitForRequestStatus(
+		ctx,
+		client,
+		"42",
+		2,
+		5*time.Second,
+		time.Second,
+		func(ctx context.Context, d time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	)
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected context cancellation error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
After `seerr_request` create/update applies a desired status, optionally poll until the observed request status matches (or timeout/cancel).

## Changes
- Add opt-in schema attributes:
  - `status_wait_timeout_seconds` (default `0` = disabled)
  - `status_wait_interval_seconds` (default `2`, min `1`)
- Add `waitForRequestStatus` helper with injectable sleep for fast unit tests
- Call wait after `applyRequestStatus` on Create and Update when timeout > 0 and status is set, then final read into state

## Tests
- `TestWaitForRequestStatusSuccess` — status 1 then 2; wait for 2 succeeds
- `TestWaitForRequestStatusTimeout` — always 1; wait for 2 fails with timeout
- `TestWaitForRequestStatusContextCancel` — cancelled context returns quickly

`go test ./internal/provider/ -count=1` passes.

Closes #81