### PR TITLE
ci: dispatch Release after auto-tag on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,3 +157,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create_annotated_tag: true
           tag_prefix: v
+
+      # Tags created with GITHUB_TOKEN do not fire on.push workflows (GitHub
+      # recursion guard). Explicitly dispatch Release so GoReleaser runs.
+      - name: Trigger Release workflow
+        if: steps.tag_version.outputs.new_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Dispatching Release for ${{ steps.tag_version.outputs.new_tag }}"
+          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${{ steps.tag_version.outputs.new_tag }}"


### PR DESCRIPTION
## Summary
Auto-tag **was** creating tags (`v0.19.6`–`v0.19.8`) after merges to `main`, but **GitHub Releases were not published**.

### Root cause
`mathieudutour/github-tag-action` pushes tags with `GITHUB_TOKEN`. GitHub does not fire `on.push` workflows for events produced by `GITHUB_TOKEN` (recursion guard). The `Release` workflow only listens for tag pushes, so GoReleaser never ran for those tags.

### Fix
After a successful auto-tag, explicitly `gh workflow run Release --ref <new_tag>` (job already has `actions: write`).

## Test plan
- [x] Confirm tags exist without releases for v0.19.6–v0.19.8
- [ ] Merge this PR
- [ ] Manually dispatch Release for backfill tags (or after merge verify next auto-tag triggers Release)
- [ ] Confirm GitHub Release + assets appear for the new tag

Closes nothing — CI fix only.