### PR TITLE
Harden GitHub Actions for external contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/terraform-core-plugins
+* @Josh-Archer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        if: matrix.language == 'go'
+        uses: github/codeql-action/autobuild@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
-    runs-on: ${{ (vars.USE_SELF_HOSTED == 'true' || vars.USE_SELF_HOSTED == true) && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    environment: release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,16 @@ permissions:
 jobs:
   build-test:
     name: Build and Test
-    runs-on: ${{ (vars.USE_SELF_HOSTED == 'true' || vars.USE_SELF_HOSTED == true) && 'self-hosted' || 'ubuntu-latest' }}
+    # Fork and same-repository PRs always use an isolated GitHub-hosted runner.
+    # Trusted runs can use UECB or an isolated self-hosted runner via this label.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
@@ -46,7 +52,11 @@ jobs:
 
   tofu-test-stable:
     name: OpenTofu Stable Integration (${{ matrix.tofu_version }})
-    runs-on: ${{ (vars.USE_SELF_HOSTED == 'true' || vars.USE_SELF_HOSTED == true) && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    environment:
+      name: ${{ github.event_name == 'pull_request' && 'public-ci' || 'integration' }}
+    permissions:
+      contents: read
     timeout-minutes: 15
     if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.integration_mode != 'full')
     strategy:
@@ -55,19 +65,21 @@ jobs:
         tofu_version:
           - 1.8.0
     env:
-      USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED }}
-      LEGACY_SEERR_URL: ${{ secrets.SEERR_URL }}
-      LEGACY_SEERR_API_KEY: ${{ secrets.SEERR_API_KEY }}
+      USE_SELF_HOSTED: ${{ github.event_name == 'pull_request' && 'false' || vars.USE_SELF_HOSTED || 'false' }}
+      LEGACY_SEERR_URL: ${{ github.event_name == 'pull_request' && '' || secrets.SEERR_URL }}
+      LEGACY_SEERR_API_KEY: ${{ github.event_name == 'pull_request' && '' || secrets.SEERR_API_KEY }}
       SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
       SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:
           tofu_version: ${{ matrix.tofu_version }}
       - name: Use legacy external Seerr target when configured
@@ -85,15 +97,19 @@ jobs:
           SEERR_TEST_SUITE: stable
       - name: Upload integration diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stable-integration-artifacts-${{ matrix.tofu_version }}
           path: test-artifacts/
           if-no-files-found: ignore
+          retention-days: 7
 
   tofu-test-full:
     name: OpenTofu Full Compatibility (${{ matrix.tofu_version }})
-    runs-on: ${{ (vars.USE_SELF_HOSTED == 'true' || vars.USE_SELF_HOSTED == true) && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    environment: integration
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.integration_mode != 'stable')
     strategy:
@@ -102,7 +118,7 @@ jobs:
         tofu_version:
           - 1.8.0
     env:
-      USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED }}
+      USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED || 'false' }}
       LEGACY_SEERR_URL: ${{ secrets.SEERR_URL }}
       LEGACY_SEERR_API_KEY: ${{ secrets.SEERR_API_KEY }}
       SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
@@ -110,12 +126,14 @@ jobs:
       SEERR_TEST_SUITE: all
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:
           tofu_version: ${{ matrix.tofu_version }}
       - name: Use legacy external Seerr target when configured
@@ -130,25 +148,27 @@ jobs:
         shell: bash
         run: bash ./scripts/test-integration.sh
       - name: Upload full-suite diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: full-integration-artifacts-${{ matrix.tofu_version }}
           path: test-artifacts/
           if-no-files-found: ignore
+          retention-days: 7
 
   auto-tag:
     name: Auto Tag
     needs: [build-test, tofu-test-stable]
     permissions:
       contents: write
-      actions: write
+      actions: read
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ${{ (vars.USE_SELF_HOSTED == 'true' || vars.USE_SELF_HOSTED == true) && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Bump version and push tag
         id: tag_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,22 +52,19 @@ jobs:
 
   tofu-test-stable:
     name: OpenTofu Stable Integration (${{ matrix.tofu_version }})
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
-    environment:
-      name: ${{ github.event_name == 'pull_request' && 'public-ci' || 'integration' }}
+    runs-on: ubuntu-latest
+    environment: public-ci
     permissions:
       contents: read
     timeout-minutes: 15
-    if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.integration_mode != 'full')
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         tofu_version:
           - 1.8.0
     env:
-      USE_SELF_HOSTED: ${{ github.event_name == 'pull_request' && 'false' || vars.USE_SELF_HOSTED || 'false' }}
-      LEGACY_SEERR_URL: ${{ github.event_name == 'pull_request' && '' || secrets.SEERR_URL }}
-      LEGACY_SEERR_API_KEY: ${{ github.event_name == 'pull_request' && '' || secrets.SEERR_API_KEY }}
+      USE_SELF_HOSTED: "false"
       SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
       SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration
     steps:
@@ -100,6 +97,59 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stable-integration-artifacts-${{ matrix.tofu_version }}
+          path: test-artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  tofu-test-stable-trusted:
+    name: OpenTofu Stable Integration Trusted (${{ matrix.tofu_version }})
+    runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    environment: integration
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.integration_mode != 'full')
+    strategy:
+      fail-fast: false
+      matrix:
+        tofu_version:
+          - 1.8.0
+    env:
+      USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED || 'false' }}
+      LEGACY_SEERR_URL: ${{ secrets.SEERR_URL }}
+      LEGACY_SEERR_API_KEY: ${{ secrets.SEERR_API_KEY }}
+      SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
+      SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration-trusted
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        with:
+          tofu_version: ${{ matrix.tofu_version }}
+      - name: Use legacy external Seerr target when configured
+        shell: bash
+        run: |
+          if [[ -n "${LEGACY_SEERR_URL:-}" ]] && [[ "${USE_SELF_HOSTED:-false}" == "false" ]]; then
+            echo "Using Legacy External Seerr Instance"
+            echo "SEERR_URL=${LEGACY_SEERR_URL}" >> "$GITHUB_ENV"
+            echo "SEERR_API_KEY=${LEGACY_SEERR_API_KEY}" >> "$GITHUB_ENV"
+          fi
+      - name: OpenTofu stable suite
+        shell: bash
+        run: bash ./scripts/test-integration.sh
+        env:
+          SEERR_TEST_SUITE: stable
+      - name: Upload integration diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: trusted-stable-integration-artifacts-${{ matrix.tofu_version }}
           path: test-artifacts/
           if-no-files-found: ignore
           retention-days: 7
@@ -158,7 +208,7 @@ jobs:
 
   auto-tag:
     name: Auto Tag
-    needs: [build-test, tofu-test-stable]
+    needs: [build-test, tofu-test-stable-trusted]
     permissions:
       contents: write
       actions: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Contributions are welcome through fork-based pull requests.
+
+1. Fork the repository and create a focused branch.
+2. Run `bash ./scripts/test-all-locally.sh` before opening a pull request.
+3. Open a pull request against `main` and link the issue it addresses.
+4. Respond to review feedback and keep the branch up to date.
+
+Pull-request CI is deliberately untrusted: it runs on `ubuntu-latest`, does not receive repository secrets, and must not be used to test private infrastructure. Integration tests use an ephemeral local Seerr target when credentials are not provided.
+
+Trusted integration runs happen only from `main`, schedules, or manually dispatched workflows. Maintainers may configure the `TRUSTED_RUNNER_LABEL` repository or organization variable to route those runs to UECB or an isolated self-hosted runner. Do not use that runner for pull requests, and do not give it access to unrelated home-network systems.
+
+Please do not include credentials, tokens, private endpoints, generated state, or personal data in issues or pull requests.

--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ SEERR_TEST_SUITE=all bash ./scripts/test-integration.sh
 
 ## CI model
 
-- Pull requests run the fast gate (`scripts/test-all-locally.sh` without integration) plus the `stable` OpenTofu integration suite.
-- Pushes to `main` run the same gate and stable integration coverage before auto-tagging.
+- Pull requests run the fast gate (`scripts/test-all-locally.sh` without integration) plus the `stable` OpenTofu integration suite against an ephemeral local Seerr target. Pull requests never receive repository secrets and always use `ubuntu-latest`.
+- Pushes to `main`, schedules, and manual runs may use the trusted runner selected by the `TRUSTED_RUNNER_LABEL` variable. Configure that label to a UECB or isolated self-hosted runner only after restricting the `integration` environment and keeping the runner off the pull-request path.
 - Scheduled runs execute the broader `full` compatibility suite only. This keeps the merge gate deterministic while still exercising dependency-sensitive coverage regularly.
 - Manual runs support three modes through the GitHub Actions `integration_mode` input: `stable`, `full`, or `both`.
-- Stable-suite artifacts upload on failure. Full-suite artifacts upload on every run so scheduled/manual compatibility failures keep their diagnostics.
+- Stable- and full-suite artifacts upload only on failure, with a seven-day retention period.
 
 Use the stable suite for merge confidence and the full suite for broader compatibility triage. If a change only fails in the full suite, treat it as an environment or unsupported-endpoint investigation unless the stable suite also regresses.
 
@@ -275,6 +275,8 @@ Releases are created from git tags matching `v*` by GitHub Actions.
 Expected secrets for signed provider releases:
 - `GPG_PRIVATE_KEY`
 - `PASSPHRASE`
+
+Configure these as secrets on the protected `release` environment, not as repository secrets. Require maintainer approval for that environment. Configure `SEERR_URL` and `SEERR_API_KEY` on the protected `integration` environment if external integration testing is needed. Repository-level secrets with these names should be removed after the environment secrets are verified.
 
 ## OpenTofu registry naming
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security policy
+
+Please do not report security vulnerabilities in public issues. Use GitHub's private vulnerability reporting for this repository when available. If that option is unavailable, contact the repository owner privately through GitHub with reproduction steps and the minimum information needed to investigate.
+
+Do not include API keys, passwords, access tokens, private URLs, or personal data in the report.
+
+Security fixes are handled privately until a coordinated disclosure decision is made.

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -180,12 +180,5 @@ elif [[ "${test_suite}" != "all" ]]; then
   exit 1
 fi
 
-run env \
-  "SEERR_URL=${SEERR_URL}" \
-  "SEERR_API_KEY=${SEERR_API_KEY}" \
-  "TF_VAR_url=${SEERR_URL}" \
-  "TF_VAR_api_key=${SEERR_API_KEY}" \
-  "${tofu_bin}" test \
-  -var="url=${SEERR_URL}" \
-  -var="api_key=${SEERR_API_KEY}" \
+run "${tofu_bin}" test \
   "${tofu_test_args[@]}" 2>&1 | tee "${tofu_test_log}"


### PR DESCRIPTION
Fixes #93

## Summary

- Keep fork and same-repository pull requests on `ubuntu-latest` without repository secrets.
- Allow trusted pushes, schedules, and manual runs to use a configured UECB or isolated self-hosted runner through `TRUSTED_RUNNER_LABEL`.
- Protect integration and release environments, main-branch reviews/checks, and release signing.
- Remove secret-bearing command-line arguments and reduce artifact retention.
- Add Dependabot, CodeQL, contributor, and security guidance.

## Validation

- YAML parsing
- `bash -n scripts/test-integration.sh`
- `go test ./...`
- `git diff --check`