### PR TITLE
Restore automatic release dispatch permission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
     needs: [build-test, tofu-test-stable-trusted]
     permissions:
       contents: write
-      actions: read
+      actions: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     steps:


### PR DESCRIPTION
Fixes #99

## Summary

- Restore the narrowly required `actions: write` permission for the trusted Auto Tag job.
- Keep all other job permissions unchanged.

The post-merge build and trusted integration passed, but automatic release dispatch failed with HTTP 403 because this permission had been reduced to read-only.

## Validation

- YAML parsing
- `git diff --check`
- Pre-push generation hook