### PR TITLE
Make automatic release tagging idempotent

### DIFF
--- a/.github/workflows/reconcile-releases.yml
+++ b/.github/workflows/reconcile-releases.yml
@@ -1,0 +1,50 @@
+name: Reconcile Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Specific historical tag to retry; leave blank for the oldest pending tag
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Reconcile orphaned release tags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout tags
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Dispatch the oldest pending release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG_OVERRIDE: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$(bash ./scripts/reconcile-release-tags.sh)"
+          tag="${result%%|*}"
+          in_flight="${result#*|}"
+
+          if [[ -z "${tag}" ]]; then
+            echo "No orphaned release tags found."
+            exit 0
+          fi
+
+          if [[ "${in_flight}" == "true" ]]; then
+            echo "Release for ${tag} is already queued or running."
+            exit 0
+          fi
+
+          echo "Dispatching Release for orphaned tag ${tag}"
+          gh workflow run Release --repo "${GITHUB_REPOSITORY}" --ref "${tag}"

--- a/.github/workflows/reconcile-releases.yml
+++ b/.github/workflows/reconcile-releases.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Specific historical tag to retry; leave blank for the oldest pending tag
+        description: Specific historical tag to retry; leave blank for the oldest eligible pending tag
         required: false
         type: string
 
@@ -15,6 +15,9 @@ jobs:
   reconcile:
     name: Reconcile orphaned release tags
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-tag-reconciliation
+      cancel-in-progress: false
     permissions:
       contents: read
       actions: write
@@ -28,7 +31,9 @@ jobs:
       - name: Dispatch the oldest pending release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_RECONCILE_FROM_TAG: ${{ vars.RELEASE_RECONCILE_FROM_TAG || 'v0.20.5' }}
           RELEASE_TAG_OVERRIDE: ${{ inputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -46,5 +51,8 @@ jobs:
             exit 0
           fi
 
-          echo "Dispatching Release for orphaned tag ${tag}"
-          gh workflow run Release --repo "${GITHUB_REPOSITORY}" --ref "${tag}"
+          echo "Dispatching the current hardened Release workflow for orphaned tag ${tag}"
+          gh workflow run release.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${DEFAULT_BRANCH}" \
+            -f "release_tag=${tag}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
 name: Release
+run-name: Release ${{ inputs.release_tag }}
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Exact version tag to build with the current hardened release workflow
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ inputs.release_tag }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -15,16 +22,82 @@ jobs:
     environment: release
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          semver_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "${RELEASE_TAG}" =~ ${semver_pattern} ]]; then
+            echo "Invalid release tag: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          gh api --silent "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}"
+
+      - name: Check release state
+        id: release_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if response="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.draft' 2>&1)"; then
+            case "${response}" in
+              false)
+                echo "published=true" >> "$GITHUB_OUTPUT"
+                echo "Release ${RELEASE_TAG} is already published; nothing to do."
+                ;;
+              true)
+                echo "published=false" >> "$GITHUB_OUTPUT"
+                echo "Release ${RELEASE_TAG} has an incomplete draft; resuming it."
+                ;;
+              *)
+                echo "Unexpected GitHub Release response: ${response}" >&2
+                exit 1
+                ;;
+            esac
+          elif [[ "${response}" == *"(HTTP 404)"* ]]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unable to inspect GitHub Release ${RELEASE_TAG}: ${response}" >&2
+            exit 1
+          fi
+
+      # Keep the publishing policy/configuration on the default branch while
+      # building the exact source tree identified by RELEASE_TAG.
+      - name: Checkout release controls
+        if: steps.release_state.outputs.published != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # workflow_dispatch resolves github.sha from the selected default-
+          # branch ref, so policy and config match the loaded workflow exactly.
+          ref: ${{ github.sha }}
+          path: release-control
+          persist-credentials: false
+
+      - name: Checkout tagged source
+        if: steps.release_state.outputs.published != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          path: source
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+
+      - name: Set up Go
+        if: steps.release_state.outputs.published != 'true'
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
+          cache-dependency-path: source/go.sum
           cache: true
+
       - name: Detect signing availability
+        if: steps.release_state.outputs.published != 'true'
         id: signing
         run: |
           if [ -n "${{ secrets.GPG_PRIVATE_KEY }}" ] && [ -n "${{ secrets.PASSPHRASE }}" ]; then
@@ -32,25 +105,30 @@ jobs:
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
+
       - name: Import GPG key
-        if: ${{ steps.signing.outputs.enabled == 'true' }}
+        if: steps.release_state.outputs.published != 'true' && steps.signing.outputs.enabled == 'true'
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser (signed)
-        if: ${{ steps.import_gpg.outputs.fingerprint != '' }}
+        if: steps.release_state.outputs.published != 'true' && steps.import_gpg.outputs.fingerprint != ''
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release --clean
+          workdir: source
+          args: release --clean --config ../release-control/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
       - name: Run GoReleaser (unsigned fallback)
-        if: ${{ steps.import_gpg.outputs.fingerprint == '' }}
+        if: steps.release_state.outputs.published != 'true' && steps.import_gpg.outputs.fingerprint == ''
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release --clean --skip=sign
+          workdir: source
+          args: release --clean --skip=sign --config ../release-control/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   goreleaser:
-    if: github.ref_name == github.event.repository.default_branch
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   goreleaser:
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     environment: release
     permissions:
@@ -83,7 +84,7 @@ jobs:
         if: steps.release_state.outputs.published != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           path: source
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,8 +220,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Find orphaned release tag
+        id: orphaned_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$(bash ./scripts/reconcile-release-tags.sh)"
+          tag="${result%%|*}"
+          in_flight="${result#*|}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "in_flight=${in_flight}" >> "$GITHUB_OUTPUT"
+
       - name: Bump version and push tag
         id: tag_version
+        if: steps.orphaned_release.outputs.tag == ''
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -230,10 +244,20 @@ jobs:
 
       # Tags created with GITHUB_TOKEN do not fire on.push workflows (GitHub
       # recursion guard). Explicitly dispatch Release so GoReleaser runs.
-      - name: Trigger Release workflow
-        if: steps.tag_version.outputs.new_tag != ''
+      - name: Retry oldest orphaned release
+        if: steps.orphaned_release.outputs.tag != '' && steps.orphaned_release.outputs.in_flight != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.orphaned_release.outputs.tag }}
         run: |
-          echo "Dispatching Release for ${{ steps.tag_version.outputs.new_tag }}"
-          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${{ steps.tag_version.outputs.new_tag }}"
+          echo "Dispatching Release for orphaned tag ${RELEASE_TAG}"
+          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${RELEASE_TAG}"
+
+      - name: Trigger Release workflow for new tag
+        if: steps.orphaned_release.outputs.tag == '' && steps.tag_version.outputs.new_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}
+        run: |
+          echo "Dispatching Release for ${RELEASE_TAG}"
+          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${RELEASE_TAG}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,14 +301,42 @@ jobs:
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          create_annotated_tag: true
+          dry_run: true
           tag_prefix: v
+
+      - name: Create annotated release tag
+        id: create_tag
+        if: steps.default_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}
+          TAG_MESSAGE: ${{ steps.tag_version.outputs.changelog }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${TAG_MESSAGE}" ]]; then
+            TAG_MESSAGE="Release ${RELEASE_TAG}"
+          fi
+          tag_object_sha="$(gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f "tag=${RELEASE_TAG}" \
+            -f "message=${TAG_MESSAGE}" \
+            -f "object=${GITHUB_SHA}" \
+            -f type=commit \
+            --jq .sha)"
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/${RELEASE_TAG}" \
+            -f "sha=${tag_object_sha}" >/dev/null
+          echo "tag_object_sha=${tag_object_sha}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify tagged commit is still the default-branch tip
         id: tagged_branch_tip
-        if: steps.default_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
+        if: steps.create_tag.outputs.tag_object_sha != ''
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_TAG_OBJECT: ${{ steps.create_tag.outputs.tag_object_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}
         shell: bash
         run: |
@@ -319,14 +347,8 @@ jobs:
             exit 0
           fi
 
-          git fetch --force origin \
-            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
-          tagged_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
-          if [[ "${tagged_commit}" != "${GITHUB_SHA}" ]]; then
-            echo "Refusing to delete ${RELEASE_TAG}: it no longer points to this run's commit." >&2
-            exit 1
-          fi
-          git push origin ":refs/tags/${RELEASE_TAG}"
+          bash ./scripts/delete-release-tag-if-unchanged.sh \
+            "${RELEASE_TAG}" "${EXPECTED_TAG_OBJECT}"
           echo "Removed stale ${RELEASE_TAG}; ${GITHUB_SHA} was no longer the ${DEFAULT_BRANCH} tip after tag creation." >&2
           exit 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,8 +282,26 @@ jobs:
             wait_for_release "${tag}"
           done
 
+      - name: Verify current default-branch tip
+        id: default_branch_tip
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          default_tip="$(git rev-parse "refs/remotes/origin/${DEFAULT_BRANCH}^{commit}")"
+          if [[ "${GITHUB_SHA}" != "${default_tip}" ]]; then
+            echo "current=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping version allocation because ${GITHUB_SHA} is no longer the ${DEFAULT_BRANCH} tip (${default_tip})."
+            exit 0
+          fi
+          echo "current=true" >> "${GITHUB_OUTPUT}"
+
       - name: Bump version and push tag
         id: tag_version
+        if: steps.default_branch_tip.outputs.current == 'true'
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -293,7 +311,7 @@ jobs:
       # Tags created with GITHUB_TOKEN do not fire on.push workflows (GitHub
       # recursion guard). Explicitly dispatch Release so GoReleaser runs.
       - name: Trigger Release workflow for new tag
-        if: steps.tag_version.outputs.new_tag != ''
+        if: steps.default_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,33 +209,81 @@ jobs:
   auto-tag:
     name: Auto Tag
     needs: [build-test, tofu-test-stable-trusted]
+    concurrency:
+      group: release-tag-reconciliation
+      cancel-in-progress: false
     permissions:
       contents: write
       actions: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 70
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Find orphaned release tag
-        id: orphaned_release
+      - name: Reconcile all eligible release tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_RECONCILE_FROM_TAG: ${{ vars.RELEASE_RECONCILE_FROM_TAG || 'v0.20.5' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         shell: bash
         run: |
           set -euo pipefail
-          result="$(bash ./scripts/reconcile-release-tags.sh)"
-          tag="${result%%|*}"
-          in_flight="${result#*|}"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "in_flight=${in_flight}" >> "$GITHUB_OUTPUT"
+          release_deadline=$((SECONDS + 3600))
+
+          wait_for_release() {
+            local tag="$1"
+            local response
+
+            while (( SECONDS < release_deadline )); do
+              if response="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.draft' 2>&1)"; then
+                if [[ "${response}" == "false" ]]; then
+                  echo "Release ${tag} is published."
+                  return 0
+                fi
+                if [[ "${response}" != "true" ]]; then
+                  echo "Unexpected GitHub Release response for ${tag}: ${response}" >&2
+                  return 1
+                fi
+              elif [[ "${response}" != *"(HTTP 404)"* ]]; then
+                echo "Unable to inspect GitHub Release ${tag}: ${response}" >&2
+                return 1
+              fi
+              sleep 10
+            done
+
+            echo "Timed out waiting for release reconciliation to finish; ${tag} is still unpublished." >&2
+            return 1
+          }
+
+          while true; do
+            result="$(bash ./scripts/reconcile-release-tags.sh)"
+            tag="${result%%|*}"
+            in_flight="${result#*|}"
+
+            if [[ -z "${tag}" ]]; then
+              echo "All eligible release tags are published."
+              break
+            fi
+
+            if [[ "${in_flight}" != "true" ]]; then
+              echo "Dispatching the current hardened Release workflow for orphaned tag ${tag}"
+              gh workflow run release.yml \
+                --repo "${GITHUB_REPOSITORY}" \
+                --ref "${DEFAULT_BRANCH}" \
+                -f "release_tag=${tag}"
+            else
+              echo "Release for ${tag} is already queued or running."
+            fi
+
+            wait_for_release "${tag}"
+          done
 
       - name: Bump version and push tag
         id: tag_version
-        if: steps.orphaned_release.outputs.tag == ''
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -244,20 +292,15 @@ jobs:
 
       # Tags created with GITHUB_TOKEN do not fire on.push workflows (GitHub
       # recursion guard). Explicitly dispatch Release so GoReleaser runs.
-      - name: Retry oldest orphaned release
-        if: steps.orphaned_release.outputs.tag != '' && steps.orphaned_release.outputs.in_flight != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.orphaned_release.outputs.tag }}
-        run: |
-          echo "Dispatching Release for orphaned tag ${RELEASE_TAG}"
-          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${RELEASE_TAG}"
-
       - name: Trigger Release workflow for new tag
-        if: steps.orphaned_release.outputs.tag == '' && steps.tag_version.outputs.new_tag != ''
+        if: steps.tag_version.outputs.new_tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           echo "Dispatching Release for ${RELEASE_TAG}"
-          gh workflow run Release --repo "$GITHUB_REPOSITORY" --ref "${RELEASE_TAG}"
+          gh workflow run release.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${DEFAULT_BRANCH}" \
+            -f "release_tag=${RELEASE_TAG}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,15 +289,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --no-tags origin \
-            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          default_tip="$(git rev-parse "refs/remotes/origin/${DEFAULT_BRANCH}^{commit}")"
-          if [[ "${GITHUB_SHA}" != "${default_tip}" ]]; then
-            echo "current=false" >> "${GITHUB_OUTPUT}"
-            echo "Skipping version allocation because ${GITHUB_SHA} is no longer the ${DEFAULT_BRANCH} tip (${default_tip})."
-            exit 0
+          current="$(bash ./scripts/release-tip-is-current.sh "${GITHUB_SHA}" "${DEFAULT_BRANCH}")"
+          echo "current=${current}" >> "${GITHUB_OUTPUT}"
+          if [[ "${current}" != "true" ]]; then
+            echo "Skipping version allocation because ${GITHUB_SHA} is no longer the ${DEFAULT_BRANCH} tip."
           fi
-          echo "current=true" >> "${GITHUB_OUTPUT}"
 
       - name: Bump version and push tag
         id: tag_version
@@ -308,10 +304,36 @@ jobs:
           create_annotated_tag: true
           tag_prefix: v
 
+      - name: Verify tagged commit is still the default-branch tip
+        id: tagged_branch_tip
+        if: steps.default_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(bash ./scripts/release-tip-is-current.sh "${GITHUB_SHA}" "${DEFAULT_BRANCH}")"
+          echo "current=${current}" >> "${GITHUB_OUTPUT}"
+          if [[ "${current}" == "true" ]]; then
+            exit 0
+          fi
+
+          git fetch --force origin \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          tagged_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          if [[ "${tagged_commit}" != "${GITHUB_SHA}" ]]; then
+            echo "Refusing to delete ${RELEASE_TAG}: it no longer points to this run's commit." >&2
+            exit 1
+          fi
+          git push origin ":refs/tags/${RELEASE_TAG}"
+          echo "Removed stale ${RELEASE_TAG}; ${GITHUB_SHA} was no longer the ${DEFAULT_BRANCH} tip after tag creation." >&2
+          exit 1
+
       # Tags created with GITHUB_TOKEN do not fire on.push workflows (GitHub
       # recursion guard). Explicitly dispatch Release so GoReleaser runs.
       - name: Trigger Release workflow for new tag
-        if: steps.default_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
+        if: steps.tagged_branch_tip.outputs.current == 'true' && steps.tag_version.outputs.new_tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag_version.outputs.new_tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,10 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  # GoReleaser creates a draft while uploading. Resume that draft after a
+  # partial publication failure and replace any assets already uploaded.
+  use_existing_draft: true
+  replace_existing_artifacts: true
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/README.md
+++ b/README.md
@@ -270,9 +270,11 @@ The hook runs the same generated-file verification used by CI and fails the push
 
 ## Release and publish
 
-Releases are created from git tags matching `v*` by GitHub Actions.
+The `Release` workflow builds an explicitly selected version tag. Auto-tagging and manual reconciliation dispatch the workflow from the default branch, so an old tag can never select an old workflow definition.
 
-Auto-tagging reconciles orphaned version tags before creating a new version. If a tag exists without a GitHub Release, the oldest pending tag is retried first; an already-running release is not duplicated. Maintainers can run the `Reconcile Releases` workflow manually when a release needs another retry without a new code push. Its optional `tag` input can explicitly backfill an older historical tag.
+Auto-tagging reconciles orphaned stable version tags before creating a new version. Automatic reconciliation starts at the repository variable `RELEASE_RECONCILE_FROM_TAG` (default `v0.20.5`), which avoids publishing intentionally skipped legacy or prerelease tags. Every eligible orphan is published before the current commit is tagged. Maintainers can run the `Reconcile Releases` workflow manually to retry the oldest eligible tag without a new code push; its optional `tag` input explicitly backfills any valid historical version tag.
+
+Release backfills always execute the current hardened workflow and publishing configuration from the default branch, then build the exact requested tag. The workflows serialize tag allocation and release dispatch, skip already-published releases, resume incomplete drafts, and fail closed when GitHub release state cannot be verified.
 
 Expected secrets for signed provider releases:
 - `GPG_PRIVATE_KEY`

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ The hook runs the same generated-file verification used by CI and fails the push
 
 Releases are created from git tags matching `v*` by GitHub Actions.
 
+Auto-tagging reconciles orphaned version tags before creating a new version. If a tag exists without a GitHub Release, the oldest pending tag is retried first; an already-running release is not duplicated. Maintainers can run the `Reconcile Releases` workflow manually when a release needs another retry without a new code push. Its optional `tag` input can explicitly backfill an older historical tag.
+
 Expected secrets for signed provider releases:
 - `GPG_PRIVATE_KEY`
 - `PASSPHRASE`

--- a/scripts/delete-release-tag-if-unchanged.sh
+++ b/scripts/delete-release-tag-if-unchanged.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:?release tag is required}"
+expected_object="${2:?expected tag object is required}"
+remote="${3:-origin}"
+
+if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid release tag: ${tag}" >&2
+  exit 2
+fi
+
+current_object="$(git ls-remote --refs "${remote}" "refs/tags/${tag}" | awk 'NR == 1 { print $1 }')"
+if [[ -z "${current_object}" ]]; then
+  echo "Refusing to delete ${tag}: the remote tag no longer exists." >&2
+  exit 1
+fi
+if [[ "${current_object}" != "${expected_object}" ]]; then
+  echo "Refusing to delete ${tag}: the remote tag object changed from ${expected_object} to ${current_object}." >&2
+  exit 1
+fi
+
+git_options=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  auth_header="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 | tr -d '\r\n')"
+  git_options+=(
+    -c
+    "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}"
+  )
+fi
+
+git "${git_options[@]}" push \
+  --force-with-lease="refs/tags/${tag}:${expected_object}" \
+  "${remote}" ":refs/tags/${tag}"

--- a/scripts/reconcile-release-tags.sh
+++ b/scripts/reconcile-release-tags.sh
@@ -1,66 +1,133 @@
 #!/usr/bin/env bash
-# Print the oldest tag that does not have a GitHub Release.
+# Print the oldest stable tag at or after the configured floor that does not
+# have a published GitHub Release.
 # Output format: <tag>|<true when a release run is already active>
 set -euo pipefail
 
 repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
-release_workflow="${RELEASE_WORKFLOW:-Release}"
+release_workflow="${RELEASE_WORKFLOW:-release.yml}"
 requested_tag="${RELEASE_TAG_OVERRIDE:-}"
-latest_release_tag="$(gh release list \
-  --repo "${repository}" \
-  --limit 100 \
-  --json tagName \
-  --jq '.[].tagName' | grep '^v' | sort -V | tail -n 1 || true)"
+reconcile_from_tag="${RELEASE_RECONCILE_FROM_TAG:-}"
+semver_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+stable_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
-is_newer_version() {
-  local candidate="$1"
+validate_tag() {
+  local tag="$1"
 
-  [[ -n "${latest_release_tag}" ]] || return 0
-  [[ "${candidate}" != "${latest_release_tag}" ]] || return 1
-  [[ "$(printf '%s\n' "${latest_release_tag}" "${candidate}" | sort -V | tail -n 1)" == "${candidate}" ]]
+  if [[ ! "${tag}" =~ ${semver_pattern} ]]; then
+    echo "Invalid release tag: ${tag}" >&2
+    return 1
+  fi
+  if ! git show-ref --verify --quiet "refs/tags/${tag}"; then
+    echo "Release tag does not exist: ${tag}" >&2
+    return 1
+  fi
+}
+
+# Return 0 for a published release, 1 when the tag has no release or only a
+# draft, and 2 for API/auth/network failures. GoReleaser can resume drafts.
+has_published_release() {
+  local tag="$1"
+  local response
+
+  if response="$(gh api "repos/${repository}/releases/tags/${tag}" --jq '.draft' 2>&1)"; then
+    case "${response}" in
+      false)
+        return 0
+        ;;
+      true)
+        return 1
+        ;;
+      *)
+        echo "Unexpected GitHub Release response for ${tag}: ${response}" >&2
+        return 2
+        ;;
+    esac
+  fi
+
+  if [[ "${response}" == *"(HTTP 404)"* ]]; then
+    return 1
+  fi
+
+  echo "Unable to inspect GitHub Release for ${tag}: ${response}" >&2
+  return 2
+}
+
+has_active_release_run() {
+  local tag="$1"
+  local active_runs
+
+  if ! active_runs="$(gh run list \
+    --workflow "${release_workflow}" \
+    --repo "${repository}" \
+    --limit 100 \
+    --json status,displayTitle \
+    --jq "[.[] | select(.displayTitle == \"Release ${tag}\" and .status != \"completed\")] | length")"; then
+    echo "Unable to inspect active Release runs for ${tag}" >&2
+    return 2
+  fi
+  if [[ ! "${active_runs}" =~ ^[0-9]+$ ]]; then
+    echo "Unexpected active Release run count for ${tag}: ${active_runs}" >&2
+    return 2
+  fi
+  [[ "${active_runs}" -gt 0 ]]
+}
+
+print_candidate() {
+  local tag="$1"
+
+  if has_active_release_run "${tag}"; then
+    printf '%s|true\n' "${tag}"
+  else
+    run_status=$?
+    if [[ "${run_status}" -eq 1 ]]; then
+      printf '%s|false\n' "${tag}"
+    else
+      return "${run_status}"
+    fi
+  fi
 }
 
 if [[ -n "${requested_tag}" ]]; then
-  git rev-parse --verify "refs/tags/${requested_tag}" >/dev/null
-  if gh release view "${requested_tag}" --repo "${repository}" >/dev/null 2>&1; then
+  validate_tag "${requested_tag}"
+  if has_published_release "${requested_tag}"; then
     printf '|false\n'
     exit 0
-  fi
-
-  active_runs="$(gh run list \
-    --workflow "${release_workflow}" \
-    --repo "${repository}" \
-    --branch "${requested_tag}" \
-    --json status \
-    --jq '[.[] | select(.status != "completed")] | length')"
-  if [[ "${active_runs}" -gt 0 ]]; then
-    printf '%s|true\n' "${requested_tag}"
   else
-    printf '%s|false\n' "${requested_tag}"
+    release_status=$?
+    [[ "${release_status}" -eq 1 ]] || exit "${release_status}"
   fi
+  print_candidate "${requested_tag}"
   exit 0
 fi
 
+if [[ -z "${reconcile_from_tag}" ]]; then
+  echo "RELEASE_RECONCILE_FROM_TAG must identify the oldest automatically managed stable tag" >&2
+  exit 1
+fi
+if [[ ! "${reconcile_from_tag}" =~ ${stable_pattern} ]]; then
+  echo "Automatic reconciliation floor must be a stable version tag: ${reconcile_from_tag}" >&2
+  exit 1
+fi
+validate_tag "${reconcile_from_tag}"
+
+reached_floor=false
 while IFS= read -r tag; do
   [[ -n "${tag}" ]] || continue
-  is_newer_version "${tag}" || continue
+  if [[ "${tag}" == "${reconcile_from_tag}" ]]; then
+    reached_floor=true
+  fi
+  [[ "${reached_floor}" == "true" ]] || continue
+  [[ "${tag}" =~ ${stable_pattern} ]] || continue
 
-  if gh release view "${tag}" --repo "${repository}" >/dev/null 2>&1; then
+  if has_published_release "${tag}"; then
     continue
-  fi
-
-  active_runs="$(gh run list \
-    --workflow "${release_workflow}" \
-    --repo "${repository}" \
-    --branch "${tag}" \
-    --json status \
-    --jq '[.[] | select(.status != "completed")] | length')"
-
-  if [[ "${active_runs}" -gt 0 ]]; then
-    printf '%s|true\n' "${tag}"
   else
-    printf '%s|false\n' "${tag}"
+    release_status=$?
+    [[ "${release_status}" -eq 1 ]] || exit "${release_status}"
   fi
+
+  print_candidate "${tag}"
   exit 0
 done < <(git tag --list 'v*' --sort=v:refname)
 

--- a/scripts/reconcile-release-tags.sh
+++ b/scripts/reconcile-release-tags.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Print the oldest tag that does not have a GitHub Release.
+# Output format: <tag>|<true when a release run is already active>
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+release_workflow="${RELEASE_WORKFLOW:-Release}"
+requested_tag="${RELEASE_TAG_OVERRIDE:-}"
+latest_release_tag="$(gh release list \
+  --repo "${repository}" \
+  --limit 100 \
+  --json tagName \
+  --jq '.[].tagName' | grep '^v' | sort -V | tail -n 1 || true)"
+
+is_newer_version() {
+  local candidate="$1"
+
+  [[ -n "${latest_release_tag}" ]] || return 0
+  [[ "${candidate}" != "${latest_release_tag}" ]] || return 1
+  [[ "$(printf '%s\n' "${latest_release_tag}" "${candidate}" | sort -V | tail -n 1)" == "${candidate}" ]]
+}
+
+if [[ -n "${requested_tag}" ]]; then
+  git rev-parse --verify "refs/tags/${requested_tag}" >/dev/null
+  if gh release view "${requested_tag}" --repo "${repository}" >/dev/null 2>&1; then
+    printf '|false\n'
+    exit 0
+  fi
+
+  active_runs="$(gh run list \
+    --workflow "${release_workflow}" \
+    --repo "${repository}" \
+    --branch "${requested_tag}" \
+    --json status \
+    --jq '[.[] | select(.status != "completed")] | length')"
+  if [[ "${active_runs}" -gt 0 ]]; then
+    printf '%s|true\n' "${requested_tag}"
+  else
+    printf '%s|false\n' "${requested_tag}"
+  fi
+  exit 0
+fi
+
+while IFS= read -r tag; do
+  [[ -n "${tag}" ]] || continue
+  is_newer_version "${tag}" || continue
+
+  if gh release view "${tag}" --repo "${repository}" >/dev/null 2>&1; then
+    continue
+  fi
+
+  active_runs="$(gh run list \
+    --workflow "${release_workflow}" \
+    --repo "${repository}" \
+    --branch "${tag}" \
+    --json status \
+    --jq '[.[] | select(.status != "completed")] | length')"
+
+  if [[ "${active_runs}" -gt 0 ]]; then
+    printf '%s|true\n' "${tag}"
+  else
+    printf '%s|false\n' "${tag}"
+  fi
+  exit 0
+done < <(git tag --list 'v*' --sort=v:refname)
+
+printf '|false\n'

--- a/scripts/reconcile-release-tags_test.sh
+++ b/scripts/reconcile-release-tags_test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 selector="${repo_root}/scripts/reconcile-release-tags.sh"
+tip_guard="${repo_root}/scripts/release-tip-is-current.sh"
 fake_bin="${repo_root}/scripts/testdata"
 test_root="$(mktemp -d)"
 fixture_repo="${test_root}/repo"
@@ -47,18 +48,6 @@ assert_output() {
 
   if [[ "${actual}" != "${expected}" ]]; then
     echo "FAIL ${name}: expected '${expected}', got '${actual}'" >&2
-    exit 1
-  fi
-  echo "PASS ${name}"
-}
-
-assert_file_contains() {
-  local name="$1"
-  local file="$2"
-  local expected="$3"
-
-  if ! grep -Fq -- "${expected}" "${file}"; then
-    echo "FAIL ${name}: '${expected}' not found in ${file}" >&2
     exit 1
   fi
   echo "PASS ${name}"
@@ -121,19 +110,76 @@ echo "PASS missing floor"
 
 release_workflow="${repo_root}/.github/workflows/release.yml"
 test_workflow="${repo_root}/.github/workflows/test.yml"
-assert_file_contains \
-  "tag checkout cannot resolve a same-named branch" \
-  "${release_workflow}" \
-  'ref: refs/tags/${{ env.RELEASE_TAG }}'
-assert_file_contains \
-  "release runs only from the default branch" \
-  "${release_workflow}" \
-  "if: github.ref_name == github.event.repository.default_branch"
-assert_file_contains \
-  "stale push guard fetches the current default-branch tip" \
-  "${test_workflow}" \
-  'refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}'
-assert_file_contains \
-  "stale push guard controls version allocation" \
-  "${test_workflow}" \
-  "if: steps.default_branch_tip.outputs.current == 'true'"
+
+tip_remote="${test_root}/tip-remote.git"
+git init -q --bare "${tip_remote}"
+git -C "${fixture_repo}" remote add tip-test "${tip_remote}"
+git -C "${fixture_repo}" branch -M main
+git -C "${fixture_repo}" push -q tip-test main
+original_tip="$(git -C "${fixture_repo}" rev-parse HEAD)"
+output="$(cd "${fixture_repo}" && RELEASE_REMOTE=tip-test bash "${tip_guard}" "${original_tip}" main)"
+assert_output "current default-branch tip is accepted" "true" "${output}"
+
+git -C "${fixture_repo}" commit -q --allow-empty -m advance
+git -C "${fixture_repo}" push -q tip-test main
+output="$(cd "${fixture_repo}" && RELEASE_REMOTE=tip-test bash "${tip_guard}" "${original_tip}" main)"
+assert_output "stale default-branch tip is rejected" "false" "${output}"
+
+python3 - "${release_workflow}" "${test_workflow}" <<'PY'
+from pathlib import Path
+import sys
+
+
+def step_block(path: Path, name: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    marker = f"      - name: {name}"
+    try:
+        start = lines.index(marker)
+    except ValueError as exc:
+        raise SystemExit(f"missing workflow step: {name}") from exc
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("      - name:"):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+release_path = Path(sys.argv[1])
+test_path = Path(sys.argv[2])
+release_text = release_path.read_text(encoding="utf-8")
+
+qualified_head_guard = (
+    "if: github.ref == format('refs/heads/{0}', "
+    "github.event.repository.default_branch)"
+)
+if qualified_head_guard not in release_text:
+    raise SystemExit("release job is not restricted to the fully qualified default-branch ref")
+
+checkout = step_block(release_path, "Checkout tagged source")
+if "ref: refs/tags/${{ env.RELEASE_TAG }}" not in checkout:
+    raise SystemExit("tagged source checkout is not fully qualified")
+
+precheck = step_block(test_path, "Verify current default-branch tip")
+if "release-tip-is-current.sh" not in precheck:
+    raise SystemExit("pre-tag default-tip behavior guard is missing")
+
+bump = step_block(test_path, "Bump version and push tag")
+if "if: steps.default_branch_tip.outputs.current == 'true'" not in bump:
+    raise SystemExit("version allocation is not gated by the pre-tag tip check")
+
+postcheck = step_block(test_path, "Verify tagged commit is still the default-branch tip")
+for required in (
+    "release-tip-is-current.sh",
+    'git push origin ":refs/tags/${RELEASE_TAG}"',
+    "tagged_commit=",
+):
+    if required not in postcheck:
+        raise SystemExit(f"post-tag stale rollback is missing: {required}")
+
+dispatch = step_block(test_path, "Trigger Release workflow for new tag")
+if "if: steps.tagged_branch_tip.outputs.current == 'true'" not in dispatch:
+    raise SystemExit("release dispatch is not gated by the post-tag tip check")
+
+print("PASS release workflow structure")
+PY

--- a/scripts/reconcile-release-tags_test.sh
+++ b/scripts/reconcile-release-tags_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 selector="${repo_root}/scripts/reconcile-release-tags.sh"
 tip_guard="${repo_root}/scripts/release-tip-is-current.sh"
+tag_rollback="${repo_root}/scripts/delete-release-tag-if-unchanged.sh"
 fake_bin="${repo_root}/scripts/testdata"
 test_root="$(mktemp -d)"
 fixture_repo="${test_root}/repo"
@@ -125,6 +126,31 @@ git -C "${fixture_repo}" push -q tip-test main
 output="$(cd "${fixture_repo}" && RELEASE_REMOTE=tip-test bash "${tip_guard}" "${original_tip}" main)"
 assert_output "stale default-branch tip is rejected" "false" "${output}"
 
+git -C "${fixture_repo}" tag -a v8.8.8 -m "stale release tag" "${original_tip}"
+git -C "${fixture_repo}" push -q tip-test refs/tags/v8.8.8
+stale_tag_object="$(git -C "${fixture_repo}" rev-parse refs/tags/v8.8.8)"
+(cd "${fixture_repo}" && bash "${tag_rollback}" v8.8.8 "${stale_tag_object}" tip-test)
+if git --git-dir="${tip_remote}" show-ref --verify --quiet refs/tags/v8.8.8; then
+  echo "FAIL unchanged tag rollback: tag still exists" >&2
+  exit 1
+fi
+echo "PASS unchanged tag rollback"
+
+git -C "${fixture_repo}" tag -f -a v8.8.8 -m "original tag" "${original_tip}"
+git -C "${fixture_repo}" push -q tip-test refs/tags/v8.8.8
+original_tag_object="$(git -C "${fixture_repo}" rev-parse refs/tags/v8.8.8)"
+git -C "${fixture_repo}" tag -f -a v8.8.8 -m "replacement tag" "${original_tip}"
+replacement_tag_object="$(git -C "${fixture_repo}" rev-parse refs/tags/v8.8.8)"
+git -C "${fixture_repo}" push -q --force tip-test refs/tags/v8.8.8
+if (cd "${fixture_repo}" && bash "${tag_rollback}" v8.8.8 "${original_tag_object}" tip-test) \
+  >"${test_root}/unexpected.out" 2>"${test_root}/rollback.err"; then
+  echo "FAIL replaced tag rollback: command succeeded unexpectedly" >&2
+  exit 1
+fi
+grep -Fq "remote tag object changed" "${test_root}/rollback.err"
+remote_tag_object="$(git --git-dir="${tip_remote}" rev-parse refs/tags/v8.8.8)"
+assert_output "replaced tag rollback is refused" "${replacement_tag_object}" "${remote_tag_object}"
+
 python3 - "${release_workflow}" "${test_workflow}" <<'PY'
 from pathlib import Path
 import sys
@@ -167,12 +193,20 @@ if "release-tip-is-current.sh" not in precheck:
 bump = step_block(test_path, "Bump version and push tag")
 if "if: steps.default_branch_tip.outputs.current == 'true'" not in bump:
     raise SystemExit("version allocation is not gated by the pre-tag tip check")
+if "dry_run: true" not in bump:
+    raise SystemExit("version calculation must not create the tag directly")
+
+create_tag = step_block(test_path, "Create annotated release tag")
+for required in ("git/tags", "git/refs", "tag_object_sha="):
+    if required not in create_tag:
+        raise SystemExit(f"annotated tag creation is missing: {required}")
 
 postcheck = step_block(test_path, "Verify tagged commit is still the default-branch tip")
 for required in (
     "release-tip-is-current.sh",
-    'git push origin ":refs/tags/${RELEASE_TAG}"',
-    "tagged_commit=",
+    "delete-release-tag-if-unchanged.sh",
+    "EXPECTED_TAG_OBJECT",
+    "GITHUB_TOKEN",
 ):
     if required not in postcheck:
         raise SystemExit(f"post-tag stale rollback is missing: {required}")

--- a/scripts/reconcile-release-tags_test.sh
+++ b/scripts/reconcile-release-tags_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+selector="${repo_root}/scripts/reconcile-release-tags.sh"
+fake_bin="${repo_root}/scripts/testdata"
+test_root="$(mktemp -d)"
+fixture_repo="${test_root}/repo"
+trap 'rm -rf "${test_root}"' EXIT
+
+git init -q "${fixture_repo}"
+git -C "${fixture_repo}" config user.email test@example.com
+git -C "${fixture_repo}" config user.name "Release Reconciler Test"
+git -C "${fixture_repo}" commit -q --allow-empty -m fixture
+for tag in \
+  v0.19.2 \
+  v0.20.0-test.1 \
+  v0.20.5 \
+  v0.20.6 \
+  v0.20.7 \
+  v0.20.9 \
+  v0.20.10; do
+  git -C "${fixture_repo}" tag "${tag}"
+done
+
+select_tag() {
+  (
+    cd "${fixture_repo}"
+    env \
+      PATH="${fake_bin}:${PATH}" \
+      GITHUB_REPOSITORY="example/repository" \
+      RELEASE_RECONCILE_FROM_TAG="${RELEASE_RECONCILE_FROM_TAG:-v0.20.5}" \
+      RELEASE_TAG_OVERRIDE="${RELEASE_TAG_OVERRIDE:-}" \
+      MOCK_PUBLISHED_TAGS="${MOCK_PUBLISHED_TAGS:-}" \
+      MOCK_DRAFT_TAGS="${MOCK_DRAFT_TAGS:-}" \
+      MOCK_ACTIVE_TAGS="${MOCK_ACTIVE_TAGS:-}" \
+      MOCK_API_ERROR_TAG="${MOCK_API_ERROR_TAG:-}" \
+      MOCK_RUN_API_ERROR="${MOCK_RUN_API_ERROR:-false}" \
+      bash "${selector}"
+  )
+}
+
+assert_output() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL ${name}: expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+  echo "PASS ${name}"
+}
+
+output="$(MOCK_PUBLISHED_TAGS=v0.20.7 select_tag)"
+assert_output "finds hole before later release" "v0.20.5|false" "${output}"
+
+output="$(MOCK_PUBLISHED_TAGS=v0.20.5,v0.20.7 select_tag)"
+assert_output "selects next hole" "v0.20.6|false" "${output}"
+
+output="$(MOCK_PUBLISHED_TAGS=v0.20.7 MOCK_ACTIVE_TAGS=v0.20.5 select_tag)"
+assert_output "reports active run" "v0.20.5|true" "${output}"
+
+output="$(MOCK_PUBLISHED_TAGS=v0.20.5,v0.20.6,v0.20.7,v0.20.9,v0.20.10 select_tag)"
+assert_output "no orphan" "|false" "${output}"
+
+output="$(MOCK_PUBLISHED_TAGS=v0.20.5,v0.20.6,v0.20.7 select_tag)"
+assert_output "version ordering" "v0.20.9|false" "${output}"
+
+output="$(RELEASE_TAG_OVERRIDE=v0.19.2 MOCK_PUBLISHED_TAGS=v0.20.7 select_tag)"
+assert_output "historical override bypasses floor" "v0.19.2|false" "${output}"
+
+output="$(RELEASE_TAG_OVERRIDE=v0.20.0-test.1 select_tag)"
+assert_output "explicit prerelease override" "v0.20.0-test.1|false" "${output}"
+
+output="$(RELEASE_TAG_OVERRIDE=v0.19.2 MOCK_PUBLISHED_TAGS=v0.19.2 select_tag)"
+assert_output "published override is a no-op" "|false" "${output}"
+
+output="$(MOCK_DRAFT_TAGS=v0.20.5 MOCK_PUBLISHED_TAGS=v0.20.7 select_tag)"
+assert_output "draft release is retryable" "v0.20.5|false" "${output}"
+
+if MOCK_API_ERROR_TAG=v0.20.5 select_tag >"${test_root}/unexpected.out" 2>"${test_root}/api.err"; then
+  echo "FAIL release API failure fails closed: command succeeded unexpectedly" >&2
+  exit 1
+fi
+grep -Fq "simulated API failure" "${test_root}/api.err"
+echo "PASS release API failure fails closed"
+
+if MOCK_RUN_API_ERROR=true select_tag >"${test_root}/unexpected.out" 2>"${test_root}/run-api.err"; then
+  echo "FAIL run API failure fails closed: command succeeded unexpectedly" >&2
+  exit 1
+fi
+grep -Fq "simulated run API failure" "${test_root}/run-api.err"
+echo "PASS run API failure fails closed"
+
+if RELEASE_TAG_OVERRIDE='v0.20.5^{commit}' select_tag >"${test_root}/unexpected.out" 2>"${test_root}/invalid.err"; then
+  echo "FAIL invalid override: command succeeded unexpectedly" >&2
+  exit 1
+fi
+grep -Fq "Invalid release tag" "${test_root}/invalid.err"
+echo "PASS invalid override"
+
+if RELEASE_RECONCILE_FROM_TAG=v9.9.9 select_tag >"${test_root}/unexpected.out" 2>"${test_root}/floor.err"; then
+  echo "FAIL missing floor: command succeeded unexpectedly" >&2
+  exit 1
+fi
+grep -Fq "Release tag does not exist" "${test_root}/floor.err"
+echo "PASS missing floor"

--- a/scripts/reconcile-release-tags_test.sh
+++ b/scripts/reconcile-release-tags_test.sh
@@ -52,6 +52,18 @@ assert_output() {
   echo "PASS ${name}"
 }
 
+assert_file_contains() {
+  local name="$1"
+  local file="$2"
+  local expected="$3"
+
+  if ! grep -Fq -- "${expected}" "${file}"; then
+    echo "FAIL ${name}: '${expected}' not found in ${file}" >&2
+    exit 1
+  fi
+  echo "PASS ${name}"
+}
+
 output="$(MOCK_PUBLISHED_TAGS=v0.20.7 select_tag)"
 assert_output "finds hole before later release" "v0.20.5|false" "${output}"
 
@@ -106,3 +118,22 @@ if RELEASE_RECONCILE_FROM_TAG=v9.9.9 select_tag >"${test_root}/unexpected.out" 2
 fi
 grep -Fq "Release tag does not exist" "${test_root}/floor.err"
 echo "PASS missing floor"
+
+release_workflow="${repo_root}/.github/workflows/release.yml"
+test_workflow="${repo_root}/.github/workflows/test.yml"
+assert_file_contains \
+  "tag checkout cannot resolve a same-named branch" \
+  "${release_workflow}" \
+  'ref: refs/tags/${{ env.RELEASE_TAG }}'
+assert_file_contains \
+  "release runs only from the default branch" \
+  "${release_workflow}" \
+  "if: github.ref_name == github.event.repository.default_branch"
+assert_file_contains \
+  "stale push guard fetches the current default-branch tip" \
+  "${test_workflow}" \
+  'refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}'
+assert_file_contains \
+  "stale push guard controls version allocation" \
+  "${test_workflow}" \
+  "if: steps.default_branch_tip.outputs.current == 'true'"

--- a/scripts/release-tip-is-current.sh
+++ b/scripts/release-tip-is-current.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_sha="${1:?expected commit SHA is required}"
+default_branch="${2:?default branch is required}"
+remote="${RELEASE_REMOTE:-origin}"
+remote_ref="refs/remotes/${remote}/${default_branch}"
+
+git fetch --no-tags "${remote}" \
+  "+refs/heads/${default_branch}:${remote_ref}" >&2
+default_tip="$(git rev-parse "${remote_ref}^{commit}")"
+expected_commit="$(git rev-parse "${expected_sha}^{commit}")"
+
+if [[ "${expected_commit}" == "${default_tip}" ]]; then
+  printf 'true\n'
+else
+  printf 'false\n'
+fi

--- a/scripts/test-all-locally.sh
+++ b/scripts/test-all-locally.sh
@@ -44,6 +44,7 @@ go_bin="$(resolve_tool go)" || {
 }
 
 run bash "${repo_root}/tools/check-generated.sh"
+run bash "${repo_root}/scripts/reconcile-release-tags_test.sh"
 run "${go_bin}" build ./...
 run "${go_bin}" test ./...
 

--- a/scripts/testdata/gh
+++ b/scripts/testdata/gh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+contains_tag() {
+  local tags="$1"
+  local needle="$2"
+
+  [[ ",${tags}," == *",${needle},"* ]]
+}
+
+command_name="${1:-}"
+shift || true
+
+case "${command_name}" in
+  api)
+    tag=""
+    for argument in "$@"; do
+      case "${argument}" in
+        repos/*/releases/tags/*)
+          tag="${argument##*/releases/tags/}"
+          ;;
+      esac
+    done
+    [[ -n "${tag}" ]] || {
+      echo "fake gh: missing release tag API path" >&2
+      exit 2
+    }
+
+    if [[ "${MOCK_API_ERROR_TAG:-}" == "${tag}" ]]; then
+      echo "gh: simulated API failure (HTTP 500)" >&2
+      exit 1
+    fi
+    if contains_tag "${MOCK_PUBLISHED_TAGS:-}" "${tag}"; then
+      printf 'false\n'
+      exit 0
+    fi
+    if contains_tag "${MOCK_DRAFT_TAGS:-}" "${tag}"; then
+      printf 'true\n'
+      exit 0
+    fi
+
+    echo "gh: Not Found (HTTP 404)" >&2
+    exit 1
+    ;;
+  run)
+    subcommand="${1:-}"
+    shift || true
+    [[ "${subcommand}" == "list" ]] || {
+      echo "fake gh: unsupported run subcommand ${subcommand}" >&2
+      exit 2
+    }
+    if [[ "${MOCK_RUN_API_ERROR:-false}" == "true" ]]; then
+      echo "gh: simulated run API failure (HTTP 500)" >&2
+      exit 1
+    fi
+
+    tag=""
+    for argument in "$@"; do
+      if [[ "${argument}" == *'Release v'* ]]; then
+        tag="${argument#*Release }"
+        tag="${tag%%\"*}"
+      fi
+    done
+    if contains_tag "${MOCK_ACTIVE_TAGS:-}" "${tag}"; then
+      printf '1\n'
+    else
+      printf '0\n'
+    fi
+    ;;
+  *)
+    echo "fake gh: unsupported command ${command_name}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Fixes #101

## Summary

- Reconcile every eligible stable tag at or after the configured release floor before allocating a new version.
- Always dispatch the current default-branch release workflow, then build the explicitly validated tag, so historical workflow definitions cannot bypass current hardening.
- Serialize release reconciliation and make the Release workflow idempotent per tag.
- Fail closed on GitHub API, authentication, and network errors.
- Resume incomplete draft releases and replace partial artifacts.
- Add a manual historical-tag override and document the release-floor policy.
- Add dependency-free reconciliation regression tests with a fake `gh` fixture.

This closes the observed gaps for `v0.20.5` and `v0.20.6` even though `v0.20.7` is already published, while excluding legacy and prerelease tags from automatic reconciliation.

## Validation

- 13 release-reconciliation scenarios
- live read-only selector check: `v0.20.5|false`
- explicit override check: `v0.20.6|false`
- `actionlint` and YAML parsing
- Bash syntax validation
- `git diff --check`
- generated-file verification
- `go build ./...`
- `go test ./...`
- GoReleaser configuration validation
- GoReleaser snapshot for historical `v0.20.5`
- final `go generate ./...`