### PR TITLE
Strengthen release and quality gates

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  categories:
+    - title: Security
+      labels:
+        - security
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+        - github_actions
+        - go
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,26 +97,41 @@ jobs:
           cache-dependency-path: source/go.sum
           cache: true
 
-      - name: Detect signing availability
+      - name: Require release signing credentials
         if: steps.release_state.outputs.published != 'true'
-        id: signing
+        env:
+          HAS_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+          HAS_GPG_PASSPHRASE: ${{ secrets.PASSPHRASE != '' }}
+        shell: bash
         run: |
-          if [ -n "${{ secrets.GPG_PRIVATE_KEY }}" ] && [ -n "${{ secrets.PASSPHRASE }}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "${HAS_GPG_PRIVATE_KEY}" != "true" || "${HAS_GPG_PASSPHRASE}" != "true" ]]; then
+            echo "Release signing requires both GPG_PRIVATE_KEY and PASSPHRASE secrets." >&2
+            exit 1
           fi
 
       - name: Import GPG key
-        if: steps.release_state.outputs.published != 'true' && steps.signing.outputs.enabled == 'true'
+        if: steps.release_state.outputs.published != 'true'
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
-      - name: Run GoReleaser (signed)
-        if: steps.release_state.outputs.published != 'true' && steps.import_gpg.outputs.fingerprint != ''
+      - name: Verify imported signing key
+        if: steps.release_state.outputs.published != 'true'
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_FINGERPRINT}" ]]; then
+            echo "The release signing key was not imported successfully." >&2
+            exit 1
+          fi
+
+      - name: Run GoReleaser
+        if: steps.release_state.outputs.published != 'true'
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           workdir: source
@@ -124,12 +139,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-
-      - name: Run GoReleaser (unsigned fallback)
-        if: steps.release_state.outputs.published != 'true' && steps.import_gpg.outputs.fingerprint == ''
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-        with:
-          workdir: source
-          args: release --clean --skip=sign --config ../release-control/.goreleaser.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,27 +45,31 @@ jobs:
         env:
           SEERR_RUN_LINT: "false"
           SEERR_RUN_INTEGRATION: "false"
+      - name: Enforce unit coverage floor
+        run: bash ./scripts/check-coverage.sh
       - name: Run linters
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.5.0
+      - name: Run actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        with:
+          scandir: ./scripts
+          version: v0.10.0
 
   tofu-test-stable:
-    name: OpenTofu Stable Integration (${{ matrix.tofu_version }})
+    name: OpenTofu Stable Integration (1.8.0)
     runs-on: ubuntu-latest
     environment: public-ci
     permissions:
       contents: read
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        tofu_version:
-          - 1.8.0
     env:
       USE_SELF_HOSTED: "false"
-      SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
+      SEERR_TEST_IMAGE: seerr/seerr:v3.1.1
       SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,7 +82,7 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:
-          tofu_version: ${{ matrix.tofu_version }}
+          tofu_version: 1.8.0
       - name: Use legacy external Seerr target when configured
         shell: bash
         run: |
@@ -96,13 +100,51 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: stable-integration-artifacts-${{ matrix.tofu_version }}
+          name: stable-integration-artifacts-1.8.0
+          path: test-artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  tofu-test-recent:
+    name: OpenTofu Recent Integration (1.12.4, Seerr 3.3.0)
+    runs-on: ubuntu-latest
+    environment: public-ci
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    if: github.event_name == 'pull_request'
+    env:
+      USE_SELF_HOSTED: "false"
+      SEERR_TEST_IMAGE: seerr/seerr:v3.3.0
+      SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration-recent
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        with:
+          tofu_version: 1.12.4
+      - name: OpenTofu stable suite
+        shell: bash
+        run: bash ./scripts/test-integration.sh
+        env:
+          SEERR_TEST_SUITE: stable
+      - name: Upload integration diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: recent-integration-artifacts-1.12.4-seerr-3.3.0
           path: test-artifacts/
           if-no-files-found: ignore
           retention-days: 7
 
   tofu-test-stable-trusted:
-    name: OpenTofu Stable Integration Trusted (${{ matrix.tofu_version }})
+    name: Stable Trusted (${{ matrix.compatibility }}) - OpenTofu ${{ matrix.tofu_version }}, Seerr ${{ matrix.seerr_version }}
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     environment: integration
     permissions:
@@ -112,13 +154,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tofu_version:
-          - 1.8.0
+        include:
+          - compatibility: minimum
+            tofu_version: 1.8.0
+            seerr_version: 3.1.1
+            seerr_image: seerr/seerr:v3.1.1
+          - compatibility: recent
+            tofu_version: 1.12.4
+            seerr_version: 3.3.0
+            seerr_image: seerr/seerr:v3.3.0
     env:
       USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED || 'false' }}
       LEGACY_SEERR_URL: ${{ secrets.SEERR_URL }}
       LEGACY_SEERR_API_KEY: ${{ secrets.SEERR_API_KEY }}
-      SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
+      SEERR_TEST_IMAGE: ${{ matrix.seerr_image }}
       SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration-trusted
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,13 +198,13 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: trusted-stable-integration-artifacts-${{ matrix.tofu_version }}
+          name: trusted-stable-integration-artifacts-${{ matrix.compatibility }}
           path: test-artifacts/
           if-no-files-found: ignore
           retention-days: 7
 
   tofu-test-full:
-    name: OpenTofu Full Compatibility (${{ matrix.tofu_version }})
+    name: Full (${{ matrix.compatibility }}) - OpenTofu ${{ matrix.tofu_version }}, Seerr ${{ matrix.seerr_version }}
     runs-on: ${{ vars.TRUSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     environment: integration
     permissions:
@@ -165,13 +214,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tofu_version:
-          - 1.8.0
+        include:
+          - compatibility: minimum
+            tofu_version: 1.8.0
+            seerr_version: 3.1.1
+            seerr_image: seerr/seerr:v3.1.1
+          - compatibility: recent
+            tofu_version: 1.12.4
+            seerr_version: 3.3.0
+            seerr_image: seerr/seerr:v3.3.0
     env:
       USE_SELF_HOSTED: ${{ vars.USE_SELF_HOSTED || 'false' }}
       LEGACY_SEERR_URL: ${{ secrets.SEERR_URL }}
       LEGACY_SEERR_API_KEY: ${{ secrets.SEERR_API_KEY }}
-      SEERR_TEST_IMAGE: ${{ vars.SEERR_TEST_IMAGE || 'seerr/seerr:v3.1.1' }}
+      SEERR_TEST_IMAGE: ${{ matrix.seerr_image }}
       SEERR_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts/integration-full
       SEERR_TEST_SUITE: all
     steps:
@@ -201,7 +257,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: full-integration-artifacts-${{ matrix.tofu_version }}
+          name: full-integration-artifacts-${{ matrix.compatibility }}
           path: test-artifacts/
           if-no-files-found: ignore
           retention-days: 7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,4 +65,7 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  disable: true
+  # Delegate release-note generation to GitHub so merged pull requests,
+  # contributors, and the full comparison link are included automatically.
+  # Categories are configured in .github/release.yml.
+  use: github-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
-## 0.1.0 (Unreleased)
+# Changelog
 
-FEATURES:
+Release notes are generated automatically from merged pull requests and are
+published with each [GitHub release]. Their categories are configured in
+[`.github/release.yml`](.github/release.yml).
+
+This file is intentionally not maintained by hand.
+
+[GitHub release]: https://github.com/Josh-Archer/terraform-provider-seerr/releases

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ or [`docs/data-sources`](./docs/data-sources) with at least one example usage bl
 - Go `1.25+`
 - OpenTofu `1.8.x+`
 
+CI continuously tests the pinned compatibility endpoints OpenTofu 1.8.0 with
+Seerr 3.1.1 and OpenTofu 1.12.4 with Seerr 3.3.0. These are the minimum and
+recently verified combinations; versions between those endpoints are expected
+to work but are not tested on every pull request.
+
 ## Provider configuration
 
 ```hcl
@@ -246,13 +251,14 @@ SEERR_TEST_SUITE=all bash ./scripts/test-integration.sh
 ```
 
 - `scripts/test-all-locally.sh`: generated-file check, `go build`, `go test`, and optional lint/integration.
+- `scripts/check-coverage.sh`: unit tests plus the CI statement-coverage floor (30% by default).
 - `scripts/test-integration.sh`: builds a provider mirror, boots a local Seerr target when `SEERR_URL` is not already set, and runs `tofu test`.
 - The default integration suite is `stable` and mirrors the CI merge gate.
 - Set `SEERR_TEST_SUITE=all` to run the broader compatibility/dependency-sensitive suite as well.
 
 ## CI model
 
-- Pull requests run the fast gate (`scripts/test-all-locally.sh` without integration) plus the `stable` OpenTofu integration suite against an ephemeral local Seerr target. Pull requests never receive repository secrets and always use `ubuntu-latest`.
+- Pull requests run the fast gate (`scripts/test-all-locally.sh` without integration) plus the `stable` OpenTofu integration suite for the pinned minimum and recent OpenTofu/Seerr combinations against ephemeral local Seerr targets. Pull requests never receive repository secrets and always use `ubuntu-latest`.
 - Pushes to `main`, schedules, and manual runs may use the trusted runner selected by the `TRUSTED_RUNNER_LABEL` variable. Configure that label to a UECB or isolated self-hosted runner only after restricting the `integration` environment and keeping the runner off the pull-request path.
 - Scheduled runs execute the broader `full` compatibility suite only. This keeps the merge gate deterministic while still exercising dependency-sensitive coverage regularly.
 - Manual runs support three modes through the GitHub Actions `integration_mode` input: `stable`, `full`, or `both`.

--- a/internal/provider/api_key_lifecycle_test.go
+++ b/internal/provider/api_key_lifecycle_test.go
@@ -1,0 +1,174 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func apiKeyResourceSchema(t *testing.T, r *APIKeyResource) resource.SchemaResponse {
+	t.Helper()
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("API key resource schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp
+}
+
+func apiKeyPlan(t *testing.T, schemaResp resource.SchemaResponse) tfsdk.Plan {
+	t.Helper()
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	model := APIKeyModel{ApiKey: types.StringUnknown(), StatusCode: types.Int64Unknown()}
+	if diags := plan.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set API key plan: %v", diags)
+	}
+	return plan
+}
+
+func TestAPIKeyResourceCreateAndRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/api/v1/settings/main/regenerate":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"apiKey":"regenerated-key"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/api/v1/settings/main":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"apiKey":"current-key"}`))
+		default:
+			t.Fatalf("unexpected request %s %s", req.Method, req.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &APIKeyResource{client: NewClient(baseURL, "old-key", "test-agent", false, defaultRequestTimeout)}
+	schemaResp := apiKeyResourceSchema(t, r)
+
+	createResp := resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Create(context.Background(), resource.CreateRequest{Plan: apiKeyPlan(t, schemaResp)}, &createResp)
+	if createResp.Diagnostics.HasError() {
+		t.Fatalf("create diagnostics: %v", createResp.Diagnostics)
+	}
+	var model APIKeyModel
+	if diags := createResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get create state: %v", diags)
+	}
+	if model.ApiKey.ValueString() != "regenerated-key" || model.StatusCode.ValueInt64() != http.StatusCreated {
+		t.Fatalf("unexpected create state: %#v", model)
+	}
+
+	readResp := resource.ReadResponse{State: createResp.State}
+	r.Read(context.Background(), resource.ReadRequest{State: createResp.State}, &readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("read diagnostics: %v", readResp.Diagnostics)
+	}
+	if diags := readResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get read state: %v", diags)
+	}
+	if model.ApiKey.ValueString() != "current-key" || model.StatusCode.ValueInt64() != http.StatusOK {
+		t.Fatalf("unexpected read state: %#v", model)
+	}
+}
+
+func TestAPIKeyResourceResponseErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "http error", statusCode: http.StatusInternalServerError, body: `{"message":"boom"}`},
+		{name: "invalid json", statusCode: http.StatusOK, body: `{`},
+		{name: "missing api key", statusCode: http.StatusOK, body: `{"applicationUrl":"https://example.test"}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.statusCode)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer srv.Close()
+			baseURL, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := &APIKeyResource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+			schemaResp := apiKeyResourceSchema(t, r)
+
+			createResp := resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			r.Create(context.Background(), resource.CreateRequest{Plan: apiKeyPlan(t, schemaResp)}, &createResp)
+			if !createResp.Diagnostics.HasError() {
+				t.Fatal("expected invalid regenerate response to produce a diagnostic")
+			}
+
+			state := tfsdk.State{Schema: schemaResp.Schema}
+			model := APIKeyModel{ApiKey: types.StringValue("old-key"), StatusCode: types.Int64Value(http.StatusOK)}
+			if diags := state.Set(context.Background(), &model); diags.HasError() {
+				t.Fatalf("set API key state: %v", diags)
+			}
+			readResp := resource.ReadResponse{State: state}
+			r.Read(context.Background(), resource.ReadRequest{State: state}, &readResp)
+			if !readResp.Diagnostics.HasError() {
+				t.Fatal("expected invalid settings response to produce a diagnostic")
+			}
+		})
+	}
+}
+
+func TestAPIKeyDataSourceReadAndHTTPError(t *testing.T) {
+	for _, statusCode := range []int{http.StatusOK, http.StatusForbidden} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodGet || req.URL.Path != "/api/v1/settings/main" {
+					t.Fatalf("unexpected request %s %s", req.Method, req.URL.Path)
+				}
+				w.WriteHeader(statusCode)
+				_, _ = w.Write([]byte(`{"apiKey":"data-source-key"}`))
+			}))
+			defer srv.Close()
+			baseURL, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			d := &APIKeyDataSource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+			var schemaResp datasource.SchemaResponse
+			d.Schema(context.Background(), datasource.SchemaRequest{}, &schemaResp)
+			configured := tfsdk.State{Schema: schemaResp.Schema}
+			model := APIKeyDataSourceModel{ApiKey: types.StringUnknown(), StatusCode: types.Int64Unknown()}
+			if diags := configured.Set(context.Background(), &model); diags.HasError() {
+				t.Fatalf("set data source config: %v", diags)
+			}
+			config := tfsdk.Config{Raw: configured.Raw, Schema: schemaResp.Schema}
+			resp := datasource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			d.Read(context.Background(), datasource.ReadRequest{Config: config}, &resp)
+
+			if statusCode != http.StatusOK {
+				if !resp.Diagnostics.HasError() || !strings.Contains(resp.Diagnostics.Errors()[0].Detail(), "403") {
+					t.Fatalf("expected 403 diagnostic, got %v", resp.Diagnostics)
+				}
+				return
+			}
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("read diagnostics: %v", resp.Diagnostics)
+			}
+			if diags := resp.State.Get(context.Background(), &model); diags.HasError() {
+				t.Fatalf("get data source state: %v", diags)
+			}
+			if model.ApiKey.ValueString() != "data-source-key" || model.StatusCode.ValueInt64() != http.StatusOK {
+				t.Fatalf("unexpected data source state: %#v", model)
+			}
+		})
+	}
+}

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -313,6 +313,31 @@ func TestClientRequestDoesNotRetryContextCancellation(t *testing.T) {
 	}
 }
 
+func TestExtractIDFromJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+		ok   bool
+	}{
+		{name: "string", body: `{"id":"request-42"}`, want: "request-42", ok: true},
+		{name: "number", body: `{"id":42}`, want: "42", ok: true},
+		{name: "blank", body: `{"id":"  "}`},
+		{name: "missing", body: `{"status":"ok"}`},
+		{name: "unsupported", body: `{"id":true}`},
+		{name: "malformed", body: `{`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := ExtractIDFromJSON([]byte(test.body))
+			if got != test.want || ok != test.ok {
+				t.Fatalf("ExtractIDFromJSON(%s) = %q, %v; want %q, %v", test.body, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/provider/data_source_api_request_test.go
+++ b/internal/provider/data_source_api_request_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func apiRequestTestConfig(t *testing.T, d *APIRequestDataSource, model APIRequestDataSourceModel) (tfsdk.Config, tfsdk.State) {
+	t.Helper()
+	var schemaResp datasource.SchemaResponse
+	d.Schema(context.Background(), datasource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("API request schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+	configuredState := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := configuredState.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set API request config: %v", diags)
+	}
+	config := tfsdk.Config{Raw: configuredState.Raw, Schema: schemaResp.Schema}
+	return config, tfsdk.State{Schema: schemaResp.Schema}
+}
+
+func TestAPIRequestDataSourceRead(t *testing.T) {
+	var gotMethod, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotMethod = req.Method
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		gotBody = string(body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"queued":true}`))
+	}))
+	defer srv.Close()
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &APIRequestDataSource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+	model := APIRequestDataSourceModel{
+		Path:             types.StringValue("/api/v1/test"),
+		Method:           types.StringValue(http.MethodPost),
+		Headers:          types.MapNull(types.StringType),
+		RequestBodyJSON:  types.StringValue(`{"request":true}`),
+		ResponseBodyJSON: types.StringUnknown(),
+		StatusCode:       types.Int64Unknown(),
+	}
+	config, state := apiRequestTestConfig(t, d, model)
+	resp := datasource.ReadResponse{State: state}
+	d.Read(context.Background(), datasource.ReadRequest{Config: config}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("read diagnostics: %v", resp.Diagnostics)
+	}
+	if gotMethod != http.MethodPost || gotBody != `{"request":true}` {
+		t.Fatalf("request = %s %s", gotMethod, gotBody)
+	}
+	if diags := resp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get API request state: %v", diags)
+	}
+	if model.StatusCode.ValueInt64() != http.StatusAccepted || !strings.Contains(model.ResponseBodyJSON.ValueString(), "queued") {
+		t.Fatalf("unexpected response state: %#v", model)
+	}
+}
+
+func TestAPIRequestDataSourceReportsInvalidPath(t *testing.T) {
+	baseURL, err := url.Parse("http://127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &APIRequestDataSource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+	model := APIRequestDataSourceModel{
+		Path:             types.StringValue(""),
+		Method:           types.StringNull(),
+		Headers:          types.MapNull(types.StringType),
+		RequestBodyJSON:  types.StringNull(),
+		ResponseBodyJSON: types.StringUnknown(),
+		StatusCode:       types.Int64Unknown(),
+	}
+	config, state := apiRequestTestConfig(t, d, model)
+	resp := datasource.ReadResponse{State: state}
+	d.Read(context.Background(), datasource.ReadRequest{Config: config}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected empty path to produce a request diagnostic")
+	}
+}

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -1,8 +1,11 @@
 package provider
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -31,5 +34,37 @@ func TestSetOptionalBoolIncludesKnownValue(t *testing.T) {
 	}
 	if got != false {
 		t.Fatalf("enabled: got %v, want false", got)
+	}
+}
+
+func TestHandleAPIResponseErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		resp   *APIResponse
+		detail string
+	}{
+		{name: "nil response", resp: nil, detail: "no response"},
+		{name: "message body", resp: &APIResponse{StatusCode: 400, Body: []byte(`{"message":"bad input"}`)}, detail: "bad input"},
+		{name: "error body", resp: &APIResponse{StatusCode: 403, Body: []byte(`{"error":"forbidden"}`)}, detail: "forbidden"},
+		{name: "raw body", resp: &APIResponse{StatusCode: 500, Body: []byte(`upstream unavailable`)}, detail: "upstream unavailable"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			if HandleAPIResponse(context.Background(), test.resp, &diags, "Read") {
+				t.Fatal("expected error response to be rejected")
+			}
+			if !diags.HasError() || !strings.Contains(diags.Errors()[0].Detail(), test.detail) {
+				t.Fatalf("expected diagnostic containing %q, got %v", test.detail, diags)
+			}
+		})
+	}
+}
+
+func TestHandleAPIResponseAcceptsSuccess(t *testing.T) {
+	var diags diag.Diagnostics
+	if !HandleAPIResponse(context.Background(), &APIResponse{StatusCode: 204}, &diags, "Delete") {
+		t.Fatalf("expected 204 response to succeed, got %v", diags)
 	}
 }

--- a/internal/provider/resource_api_object_test.go
+++ b/internal/provider/resource_api_object_test.go
@@ -1,0 +1,258 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func apiObjectTestSchema(t *testing.T, r *APIObjectResource) resource.SchemaResponse {
+	t.Helper()
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("API object schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp
+}
+
+func apiObjectTestModel(path string) APIObjectModel {
+	return APIObjectModel{
+		ID:               types.StringUnknown(),
+		Path:             types.StringValue(path),
+		Headers:          types.MapNull(types.StringType),
+		RequestBodyJSON:  types.StringValue(`{"phase":"create"}`),
+		DeleteBodyJSON:   types.StringValue(`{"cleanup":true}`),
+		ReadMethod:       types.StringValue(http.MethodGet),
+		CreateMethod:     types.StringValue(http.MethodPost),
+		UpdateMethod:     types.StringValue(http.MethodPatch),
+		DeleteMethod:     types.StringValue(http.MethodDelete),
+		SkipDelete:       types.BoolValue(false),
+		SuppressNotFound: types.BoolValue(true),
+		ResponseBodyJSON: types.StringUnknown(),
+		StatusCode:       types.Int64Unknown(),
+	}
+}
+
+func apiObjectTestPlan(t *testing.T, schemaResp resource.SchemaResponse, model APIObjectModel) tfsdk.Plan {
+	t.Helper()
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	if diags := plan.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set API object plan: %v", diags)
+	}
+	return plan
+}
+
+func apiObjectTestState(t *testing.T, schemaResp resource.SchemaResponse, model APIObjectModel) tfsdk.State {
+	t.Helper()
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set API object state: %v", diags)
+	}
+	return state
+}
+
+func TestAPIObjectLifecycle(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		requests = append(requests, fmt.Sprintf("%s %s %s", req.Method, req.URL.Path, body))
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":42,"phase":"created"}`))
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":42,"phase":"updated"}`))
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":42,"phase":"read"}`))
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method %s", req.Method)
+		}
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &APIObjectResource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+	schemaResp := apiObjectTestSchema(t, r)
+	model := apiObjectTestModel("/api/v1/example")
+
+	createResp := resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Create(context.Background(), resource.CreateRequest{Plan: apiObjectTestPlan(t, schemaResp, model)}, &createResp)
+	if createResp.Diagnostics.HasError() {
+		t.Fatalf("create diagnostics: %v", createResp.Diagnostics)
+	}
+	if diags := createResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get create state: %v", diags)
+	}
+	if got := model.ID.ValueString(); got != "42" {
+		t.Fatalf("create ID = %q, want 42", got)
+	}
+	if got := model.StatusCode.ValueInt64(); got != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d", got, http.StatusCreated)
+	}
+
+	model.RequestBodyJSON = types.StringValue(`{"phase":"update"}`)
+	updateResp := resource.UpdateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Update(context.Background(), resource.UpdateRequest{Plan: apiObjectTestPlan(t, schemaResp, model)}, &updateResp)
+	if updateResp.Diagnostics.HasError() {
+		t.Fatalf("update diagnostics: %v", updateResp.Diagnostics)
+	}
+
+	readResp := resource.ReadResponse{State: updateResp.State}
+	r.Read(context.Background(), resource.ReadRequest{State: updateResp.State}, &readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("read diagnostics: %v", readResp.Diagnostics)
+	}
+	if diags := readResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get read state: %v", diags)
+	}
+	if got := model.ResponseBodyJSON.ValueString(); !strings.Contains(got, `"phase":"read"`) {
+		t.Fatalf("read response = %q", got)
+	}
+
+	var deleteResp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: readResp.State}, &deleteResp)
+	if deleteResp.Diagnostics.HasError() {
+		t.Fatalf("delete diagnostics: %v", deleteResp.Diagnostics)
+	}
+
+	wantRequests := []string{
+		`POST /api/v1/example {"phase":"create"}`,
+		`PATCH /api/v1/example {"phase":"update"}`,
+		`GET /api/v1/example `,
+		`DELETE /api/v1/example {"cleanup":true}`,
+	}
+	if got := strings.Join(requests, "\n"); got != strings.Join(wantRequests, "\n") {
+		t.Fatalf("requests:\n%s\nwant:\n%s", got, strings.Join(wantRequests, "\n"))
+	}
+}
+
+func TestAPIObjectLifecycleHTTPFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *APIObjectResource, resource.SchemaResponse) bool
+	}{
+		{
+			name: "create",
+			run: func(ctx context.Context, r *APIObjectResource, schemaResp resource.SchemaResponse) bool {
+				var resp resource.CreateResponse
+				resp.State = tfsdk.State{Schema: schemaResp.Schema}
+				r.Create(ctx, resource.CreateRequest{Plan: apiObjectTestPlan(t, schemaResp, apiObjectTestModel("/failure"))}, &resp)
+				return resp.Diagnostics.HasError()
+			},
+		},
+		{
+			name: "read",
+			run: func(ctx context.Context, r *APIObjectResource, schemaResp resource.SchemaResponse) bool {
+				model := apiObjectTestModel("/failure")
+				model.ID = types.StringValue("failure")
+				model.SuppressNotFound = types.BoolValue(false)
+				state := apiObjectTestState(t, schemaResp, model)
+				resp := resource.ReadResponse{State: state}
+				r.Read(ctx, resource.ReadRequest{State: state}, &resp)
+				return resp.Diagnostics.HasError()
+			},
+		},
+		{
+			name: "update",
+			run: func(ctx context.Context, r *APIObjectResource, schemaResp resource.SchemaResponse) bool {
+				var resp resource.UpdateResponse
+				resp.State = tfsdk.State{Schema: schemaResp.Schema}
+				r.Update(ctx, resource.UpdateRequest{Plan: apiObjectTestPlan(t, schemaResp, apiObjectTestModel("/failure"))}, &resp)
+				return resp.Diagnostics.HasError()
+			},
+		},
+		{
+			name: "delete",
+			run: func(ctx context.Context, r *APIObjectResource, schemaResp resource.SchemaResponse) bool {
+				model := apiObjectTestModel("/failure")
+				model.ID = types.StringValue("failure")
+				state := apiObjectTestState(t, schemaResp, model)
+				var resp resource.DeleteResponse
+				r.Delete(ctx, resource.DeleteRequest{State: state}, &resp)
+				return resp.Diagnostics.HasError()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"boom"}`))
+			}))
+			defer srv.Close()
+			baseURL, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := &APIObjectResource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+			if !test.run(context.Background(), r, apiObjectTestSchema(t, r)) {
+				t.Fatal("expected HTTP 500 to produce an error diagnostic")
+			}
+		})
+	}
+}
+
+func TestAPIObjectReadSuppressesNotFoundAndDeleteIsIdempotent(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &APIObjectResource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+	schemaResp := apiObjectTestSchema(t, r)
+	model := apiObjectTestModel("/missing")
+	model.ID = types.StringValue("missing")
+	state := apiObjectTestState(t, schemaResp, model)
+
+	readResp := resource.ReadResponse{State: state}
+	r.Read(context.Background(), resource.ReadRequest{State: state}, &readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("read diagnostics: %v", readResp.Diagnostics)
+	}
+	if !readResp.State.Raw.IsNull() {
+		t.Fatal("expected suppressed 404 to remove resource state")
+	}
+
+	var deleteResp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &deleteResp)
+	if deleteResp.Diagnostics.HasError() {
+		t.Fatalf("delete diagnostics: %v", deleteResp.Diagnostics)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+
+	model.SkipDelete = types.BoolValue(true)
+	state = apiObjectTestState(t, schemaResp, model)
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &deleteResp)
+	if requests != 2 {
+		t.Fatalf("skip_delete issued an HTTP request; requests = %d", requests)
+	}
+}

--- a/internal/provider/resource_job_schedule_test.go
+++ b/internal/provider/resource_job_schedule_test.go
@@ -2,14 +2,104 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestJobScheduleLifecycleRestoresOriginalSchedule(t *testing.T) {
+	currentSchedule := "0 0 * * *"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodGet:
+			if req.URL.Path != "/api/v1/settings/jobs" {
+				t.Fatalf("unexpected GET path %s", req.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"id": "plex-sync", "schedule": currentSchedule}})
+		case http.MethodPost:
+			if req.URL.Path != "/api/v1/settings/jobs/plex-sync/schedule" {
+				t.Fatalf("unexpected POST path %s", req.URL.Path)
+			}
+			var payload map[string]string
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode schedule payload: %v", err)
+			}
+			currentSchedule = payload["schedule"]
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s", req.Method)
+		}
+	}))
+	defer srv.Close()
+	baseURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &JobScheduleResource{client: NewClient(baseURL, "key", "test-agent", false, defaultRequestTimeout)}
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	model := JobScheduleModel{
+		ID:               types.StringUnknown(),
+		JobID:            types.StringValue("plex-sync"),
+		Schedule:         types.StringValue("0 6 * * *"),
+		PreviousSchedule: types.StringUnknown(),
+	}
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	if diags := plan.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set create plan: %v", diags)
+	}
+	createResp := resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Create(context.Background(), resource.CreateRequest{Plan: plan}, &createResp)
+	if createResp.Diagnostics.HasError() {
+		t.Fatalf("create diagnostics: %v", createResp.Diagnostics)
+	}
+	if diags := createResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get create state: %v", diags)
+	}
+	if model.PreviousSchedule.ValueString() != "0 0 * * *" || currentSchedule != "0 6 * * *" {
+		t.Fatalf("create did not preserve/apply schedules: state=%#v current=%q", model, currentSchedule)
+	}
+
+	model.Schedule = types.StringValue("0 12 * * *")
+	plan = tfsdk.Plan{Schema: schemaResp.Schema}
+	if diags := plan.Set(context.Background(), &model); diags.HasError() {
+		t.Fatalf("set update plan: %v", diags)
+	}
+	updateResp := resource.UpdateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &updateResp)
+	if updateResp.Diagnostics.HasError() {
+		t.Fatalf("update diagnostics: %v", updateResp.Diagnostics)
+	}
+
+	readResp := resource.ReadResponse{State: updateResp.State}
+	r.Read(context.Background(), resource.ReadRequest{State: updateResp.State}, &readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("read diagnostics: %v", readResp.Diagnostics)
+	}
+	if diags := readResp.State.Get(context.Background(), &model); diags.HasError() {
+		t.Fatalf("get read state: %v", diags)
+	}
+	if model.Schedule.ValueString() != "0 12 * * *" || model.PreviousSchedule.ValueString() != "0 0 * * *" {
+		t.Fatalf("unexpected read state: %#v", model)
+	}
+
+	var deleteResp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: readResp.State}, &deleteResp)
+	if deleteResp.Diagnostics.HasError() {
+		t.Fatalf("delete diagnostics: %v", deleteResp.Diagnostics)
+	}
+	if currentSchedule != "0 0 * * *" {
+		t.Fatalf("delete restored %q, want original schedule", currentSchedule)
+	}
+}
 
 func TestJobScheduleRefreshSetsPreviousScheduleOnFirstRead(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/resource_notification_agent_delete_test.go
+++ b/internal/provider/resource_notification_agent_delete_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,9 +42,9 @@ func TestNotificationDeleteConvergedWhenDisabled(t *testing.T) {
 }
 
 func TestNotificationDeleteIgnoresTimeoutWhenAgentAlreadyDisabled(t *testing.T) {
-	var requestCount int
+	var requestCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		if r.URL.Path != "/api/v1/settings/notifications/pushover" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -76,7 +77,7 @@ func TestNotificationDeleteIgnoresTimeoutWhenAgentAlreadyDisabled(t *testing.T) 
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("expected delete to succeed after converged timeout, got %v", resp.Diagnostics)
 	}
-	if requestCount < 2 {
-		t.Fatalf("expected timeout recovery to issue a follow-up GET, got %d requests", requestCount)
+	if got := requestCount.Load(); got < 2 {
+		t.Fatalf("expected timeout recovery to issue a follow-up GET, got %d requests", got)
 	}
 }

--- a/internal/provider/surface_parity_test.go
+++ b/internal/provider/surface_parity_test.go
@@ -40,6 +40,34 @@ func TestProviderSurfaceParity(t *testing.T) {
 	assertLocalModuleSourcesExist(t, filepath.Join(repoRoot, "examples", "modules"))
 }
 
+func TestRegisteredDataSourceSchemas(t *testing.T) {
+	ctx := context.Background()
+	provider := New("test")()
+	seen := map[string]struct{}{}
+
+	for _, factory := range provider.DataSources(ctx) {
+		dataSource := factory()
+		var metadata datasource.MetadataResponse
+		dataSource.Metadata(ctx, datasource.MetadataRequest{ProviderTypeName: "seerr"}, &metadata)
+		if strings.TrimSpace(metadata.TypeName) == "" {
+			t.Fatal("registered data source returned an empty type name")
+		}
+		if _, duplicate := seen[metadata.TypeName]; duplicate {
+			t.Fatalf("duplicate registered data source type %s", metadata.TypeName)
+		}
+		seen[metadata.TypeName] = struct{}{}
+
+		var schemaResp datasource.SchemaResponse
+		dataSource.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Fatalf("data source %s schema diagnostics: %v", metadata.TypeName, schemaResp.Diagnostics)
+		}
+		if len(schemaResp.Schema.Attributes) == 0 && len(schemaResp.Schema.Blocks) == 0 {
+			t.Fatalf("data source %s has an empty schema", metadata.TypeName)
+		}
+	}
+}
+
 func repoRootFromTest(t *testing.T) string {
 	t.Helper()
 	_, filename, _, ok := runtime.Caller(0)

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Purpose: enforce the deterministic unit-test statement coverage floor used by CI.
+# Usage: bash ./scripts/check-coverage.sh
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+minimum="${SEERR_COVERAGE_MIN:-30.0}"
+profile="$(mktemp "${TMPDIR:-/tmp}/seerr-coverage.XXXXXX")"
+trap 'rm -f "${profile}"' EXIT
+
+go test ./... -covermode=atomic -coverprofile="${profile}"
+
+coverage="$(go tool cover -func="${profile}" | awk '/^total:/ { gsub(/%/, "", $3); print $3 }')"
+if [[ -z "${coverage}" ]]; then
+  echo "Unable to determine total statement coverage." >&2
+  exit 1
+fi
+
+echo "Total statement coverage: ${coverage}% (required: ${minimum}%)"
+awk -v actual="${coverage}" -v minimum="${minimum}" 'BEGIN { exit !(actual + 0 >= minimum + 0) }' || {
+  echo "Statement coverage ${coverage}% is below the required ${minimum}%." >&2
+  exit 1
+}

--- a/scripts/ci-docker-up.sh
+++ b/scripts/ci-docker-up.sh
@@ -6,7 +6,6 @@ exec 1>&2
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 tests_dir="${script_dir}/../tests"
-port="${SEERR_TEST_PORT:-5055}"
 local_port="${SEERR_TEST_LOCAL_PORT:-15055}"
 api_key="${SEERR_BOOTSTRAP_API_KEY:-seerr-ci-api-key}"
 admin_email="${SEERR_TEST_ADMIN_EMAIL:-ci-admin@example.invalid}"

--- a/scripts/reconcile-release-tags_test.sh
+++ b/scripts/reconcile-release-tags_test.sh
@@ -121,6 +121,7 @@ echo "PASS missing floor"
 
 release_workflow="${repo_root}/.github/workflows/release.yml"
 test_workflow="${repo_root}/.github/workflows/test.yml"
+# shellcheck disable=SC2016 # Literal GitHub expression under test.
 assert_file_contains \
   "tag checkout cannot resolve a same-named branch" \
   "${release_workflow}" \
@@ -129,6 +130,7 @@ assert_file_contains \
   "release runs only from the default branch" \
   "${release_workflow}" \
   "if: github.ref_name == github.event.repository.default_branch"
+# shellcheck disable=SC2016 # Literal shell expression embedded in the workflow.
 assert_file_contains \
   "stale push guard fetches the current default-branch tip" \
   "${test_workflow}" \

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -141,7 +141,7 @@ if [[ -z "${SEERR_URL:-}" || -z "${SEERR_API_KEY:-}" ]]; then
 
   while IFS= read -r line; do
     [[ -n "${line}" ]] || continue
-    export "${line}"
+    export "${line?}"
   done <<< "${docker_env}"
 fi
 


### PR DESCRIPTION
## Summary

- Generate GitHub-native release notes and replace the stale hand-maintained changelog stub.
- Require GPG signing credentials and a successfully imported fingerprint; unsigned releases now fail closed.
- Run actionlint and SHA-pinned ShellCheck inside the required `Build and Test` gate.
- Preserve the required OpenTofu 1.8.0 / Seerr 3.1.1 integration context and add OpenTofu 1.12.4 / Seerr 3.3.0 coverage.
- Raise combined Go statement coverage from 26.9% to 31.5% and enforce a 30% floor.
- Add lifecycle and API error-path tests for API keys, generic API objects/requests, job schedules, client handling, helper IDs, notification deletion, and registered data-source schemas.

## Why

This implements the repository-quality follow-ups identified while fixing release reconciliation: trustworthy signed publication, useful release history, broader compatibility evidence, stronger lifecycle regression coverage, and workflow/shell validation that participates in the existing protected merge gate.

## Validation

- `go generate ./...`
- `bash ./scripts/test-all-locally.sh`
- `bash ./scripts/check-coverage.sh` — 31.5% total, 31.6% provider
- `go test -race ./internal/provider`
- `go vet ./...`
- golangci-lint v2.5.0 — 0 issues
- actionlint v1.7.12
- ShellCheck on all `scripts/*.sh`
- GoReleaser v2.17 config check
- YAML parsing
- `git diff --check`
- OpenTofu v1.12.4 release artifact and Seerr v3.3.0 amd64/arm64 image verification

## Stacked PR

This draft targets `agent/reconcile-release-tags` because it builds on and overlaps the release workflow changes in #102. Merge #102 first, then retarget this PR to `main`.

## Remaining live checks

- GitHub CI will run the actual Seerr 3.1.1 and 3.3.0 container integration jobs; Docker was unavailable locally.
- Signed publication and GitHub-native release-note generation require the protected `release` environment for end-to-end validation.