### PR TITLE
Fix seerr_user data source casing

### DIFF
--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -129,7 +129,15 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	// Populate Data Source
+	if err := populateUserDataSourceModel(&data, matchedUser); err != nil {
+		resp.Diagnostics.AddError("Parse Error", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func populateUserDataSourceModel(data *UserDataSourceModel, matchedUser map[string]any) error {
 	idRaw := matchedUser["id"]
 	switch v := idRaw.(type) {
 	case float64:
@@ -137,15 +145,14 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	case string:
 		data.ID = types.StringValue(v)
 	default:
-		resp.Diagnostics.AddError("Parse Error", "Could not parse user ID.")
-		return
+		return fmt.Errorf("could not parse user ID")
 	}
 
 	if e, ok := matchedUser["email"].(string); ok {
-		data.Email = types.StringValue(strings.ToLower(e))
+		data.Email = types.StringValue(e)
 	}
 	if un, ok := matchedUser["username"].(string); ok {
-		data.Username = types.StringValue(strings.ToLower(un))
+		data.Username = types.StringValue(un)
 	}
 	if p, ok := matchedUser["permissions"].(float64); ok {
 		data.Permissions = types.Int64Value(int64(p))
@@ -155,5 +162,5 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	return nil
 }

--- a/internal/provider/data_source_user_test.go
+++ b/internal/provider/data_source_user_test.go
@@ -4,8 +4,35 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestPopulateUserDataSourceModelPreservesAPICasing(t *testing.T) {
+	data := UserDataSourceModel{}
+	err := populateUserDataSourceModel(&data, map[string]any{
+		"id":          float64(42),
+		"email":       "Case.Sensitive@Example.COM",
+		"username":    "MixedCaseUser",
+		"permissions": "7",
+	})
+	if err != nil {
+		t.Fatalf("populate user data source model: %v", err)
+	}
+
+	if got, want := data.ID, types.StringValue("42"); !got.Equal(want) {
+		t.Fatalf("id = %q, want %q", got.ValueString(), want.ValueString())
+	}
+	if got, want := data.Email, types.StringValue("Case.Sensitive@Example.COM"); !got.Equal(want) {
+		t.Fatalf("email = %q, want %q", got.ValueString(), want.ValueString())
+	}
+	if got, want := data.Username, types.StringValue("MixedCaseUser"); !got.Equal(want) {
+		t.Fatalf("username = %q, want %q", got.ValueString(), want.ValueString())
+	}
+	if got := data.Permissions.ValueInt64(); got != 7 {
+		t.Fatalf("permissions = %d, want 7", got)
+	}
+}
 
 func TestAccUserDataSource(t *testing.T) {
 	username := "terraform_ds_test_user"


### PR DESCRIPTION
## Summary

Preserves the canonical email and username casing returned by Seerr in `seerr_user` data-source state.

## Root cause

The data source correctly used case-insensitive comparisons to find users, but then lowercased the matching API values before writing state. That changed the remote representation and could break downstream case-sensitive comparisons.

## Validation

- `go test ./...`
- Repository generated-file check executed by the pre-push hook

Closes #105.