### PR TITLE
feat: validate published modules and module examples in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
+        with:
+          tofu_version: 1.8.0
       - run: go mod download
       - name: Run fast merge gate
         run: bash ./scripts/test-all-locally.sh
@@ -366,3 +370,4 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --ref "${DEFAULT_BRANCH}" \
             -f "release_tag=${RELEASE_TAG}"
+

--- a/examples/modules/seerr_arr_integration/main.tf
+++ b/examples/modules/seerr_arr_integration/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    seerr = {
+      source = "josh-archer/seerr"
+    }
+  }
+}
+
 provider "seerr" {
   url     = var.seerr_url
   api_key = var.seerr_api_key

--- a/scripts/test-all-locally.sh
+++ b/scripts/test-all-locally.sh
@@ -72,6 +72,13 @@ case "${SEERR_RUN_LINT:-auto}" in
     ;;
 esac
 
+if tofu_bin="$(resolve_tool tofu)"; then
+  run bash "${repo_root}/scripts/validate-modules.sh"
+else
+  echo "Skipping module validation; 'tofu' command not found on PATH" >&2
+fi
+
 if [[ "${SEERR_RUN_INTEGRATION:-false}" == "true" ]]; then
   run bash "${repo_root}/scripts/test-integration.sh"
 fi
+

--- a/scripts/testdata/invalid_module/main.tf
+++ b/scripts/testdata/invalid_module/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    seerr = {
+      source = "josh-archer/seerr"
+    }
+  }
+}
+
+resource "seerr_main_settings" "invalid" {
+  app_title              = "Test"
+  application_url        = "http://localhost:5055"
+  this_argument_does_not_exist = true # This should trigger a schema validation error
+}

--- a/scripts/validate-modules.sh
+++ b/scripts/validate-modules.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export TF_CLI_CONFIG_FILE="${repo_root}/.tofurc"
+
+echo "Building provider locally..."
+mkdir -p "${repo_root}/.bin"
+cd "${repo_root}"
+go build -o "${repo_root}/.bin/terraform-provider-seerr" .
+go build -o "${repo_root}/.bin/terraform-provider-seerr.exe" . || true
+
+echo "Generating .tofurc..."
+bin_dir="${repo_root}/.bin"
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+  bin_dir=$(cygpath -m "$bin_dir")
+fi
+
+cat <<EOF > "${TF_CLI_CONFIG_FILE}"
+provider_installation {
+  dev_overrides {
+    "registry.opentofu.org/josh-archer/seerr" = "${bin_dir}"
+    "registry.terraform.io/josh-archer/seerr" = "${bin_dir}"
+    "josh-archer/seerr" = "${bin_dir}"
+  }
+  direct {}
+}
+EOF
+
+echo "Running regression test..."
+cd "${repo_root}/scripts/testdata/invalid_module"
+tofu init -backend=false
+if tofu validate; then
+  echo "Regression test failed: validate should have caught the invalid argument"
+  exit 1
+else
+  echo "Regression test passed: invalid argument caught."
+fi
+
+echo "Validating modules..."
+for d in "${repo_root}/modules"/* "${repo_root}/examples/modules"/*; do
+  if [ -d "$d" ]; then
+    echo "Validating $d..."
+    cd "$d"
+    tofu init -backend=false
+    tofu validate
+  fi
+done
+
+echo "Module validation complete."

--- a/scripts/validate-modules.sh
+++ b/scripts/validate-modules.sh
@@ -38,13 +38,18 @@ else
 fi
 
 echo "Validating modules..."
+shopt -s nullglob
 for d in "${repo_root}/modules"/* "${repo_root}/examples/modules"/*; do
   if [ -d "$d" ]; then
     echo "Validating $d..."
     cd "$d"
-    tofu init -backend=false
+    # Provider resolution still requires init for nested modules, even with
+    # development overrides. All modules must declare josh-archer/seerr so
+    # OpenTofu does not invent a hashicorp/seerr dependency.
+    tofu init -backend=false -input=false
     tofu validate
   fi
 done
+shopt -u nullglob
 
 echo "Module validation complete."


### PR DESCRIPTION
Closes #107. Adds module validation tests under a CI-safe validation path (using tofu init/validate) and configures validation tests as CI/CD Gates.