### PR TITLE
feat: document and support plex-token bootstrap configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,24 @@ Provider for Seerr APIs.
 ## Example Usage
 
 ```terraform
+# Standard setup using an API key
 provider "seerr" {
   url     = "https://seerr.example.com"
   api_key = var.seerr_api_key
 }
 
 variable "seerr_api_key" {
+  type      = string
+  sensitive = true
+}
+
+# First-run setup using a Plex token to bootstrap the API key
+provider "seerr" {
+  url        = "https://seerr.example.com"
+  plex_token = var.plex_token
+}
+
+variable "plex_token" {
   type      = string
   sensitive = true
 }
@@ -30,7 +42,7 @@ variable "seerr_api_key" {
 
 - `api_key` (String, Sensitive) Seerr API key used as the `X-Api-Key` header. Required if `plex_token` is not set. Can also be configured via the `SEERR_API_KEY` environment variable.
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification.
-- `plex_token` (String, Sensitive) Plex token used as the `X-Plex-Token` header for authentication. This token must belong to a server admin user in order to be used for the setup flow. Required if `api_key` is not set.
+- `plex_token` (String, Sensitive) Plex token used to authenticate with Seerr and fetch the API key. This token must belong to a server admin user in order to be used for the setup flow. Required if `api_key` is not set. Can also be configured via the `SEERR_PLEX_TOKEN` environment variable.
 - `request_timeout_seconds` (Number) HTTP request timeout in seconds for Seerr API calls and ARR quality-profile lookups. Defaults to 120 seconds. Can also be configured via the `SEERR_REQUEST_TIMEOUT_SECONDS` environment variable.
 - `url` (String) Base URL for Seerr, for example `https://seerr.example.com`. Can also be configured via the `SEERR_URL` environment variable.
 - `user_agent` (String) Optional custom User-Agent header.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,4 @@
+# Standard setup using an API key
 provider "seerr" {
   url     = "https://seerr.example.com"
   api_key = var.seerr_api_key
@@ -8,3 +9,13 @@ variable "seerr_api_key" {
   sensitive = true
 }
 
+# First-run setup using a Plex token to bootstrap the API key
+provider "seerr" {
+  url        = "https://seerr.example.com"
+  plex_token = var.plex_token
+}
+
+variable "plex_token" {
+  type      = string
+  sensitive = true
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,7 +69,7 @@ func (p *SeerrProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp
 				Sensitive:           true,
 			},
 			"plex_token": schema.StringAttribute{
-				MarkdownDescription: "Plex token used as the `X-Plex-Token` header for authentication. This token must belong to a server admin user in order to be used for the setup flow. Required if `api_key` is not set.",
+				MarkdownDescription: "Plex token used to authenticate with Seerr and fetch the API key. This token must belong to a server admin user in order to be used for the setup flow. Required if `api_key` is not set. Can also be configured via the `SEERR_PLEX_TOKEN` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
 			},
@@ -255,6 +255,9 @@ func resolveProviderConfigValues(data SeerrProviderModel, version string, getenv
 	}
 	if config.APIKey == "" {
 		config.APIKey = strings.TrimSpace(getenv("SEERR_API_KEY"))
+	}
+	if config.PlexToken == "" {
+		config.PlexToken = strings.TrimSpace(getenv("SEERR_PLEX_TOKEN"))
 	}
 	if !data.UserAgent.IsNull() && !data.UserAgent.IsUnknown() && strings.TrimSpace(data.UserAgent.ValueString()) != "" {
 		config.UserAgent = strings.TrimSpace(data.UserAgent.ValueString())

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -65,6 +65,8 @@ func TestResolveProviderConfigValuesUsesEnvironmentFallbacks(t *testing.T) {
 			return "https://seerr.example.com"
 		case "SEERR_API_KEY":
 			return "secret"
+		case "SEERR_PLEX_TOKEN":
+			return "plex-secret"
 		case "SEERR_REQUEST_TIMEOUT_SECONDS":
 			return "45"
 		default:
@@ -79,6 +81,9 @@ func TestResolveProviderConfigValuesUsesEnvironmentFallbacks(t *testing.T) {
 	}
 	if config.APIKey != "secret" {
 		t.Fatalf("expected env API key, got %q", config.APIKey)
+	}
+	if config.PlexToken != "plex-secret" {
+		t.Fatalf("expected env Plex token, got %q", config.PlexToken)
 	}
 	if config.RequestTimeout != 45*time.Second {
 		t.Fatalf("expected 45s timeout, got %s", config.RequestTimeout)


### PR DESCRIPTION
Closes #106. Adds support for SEERR_PLEX_TOKEN environment variable with proper precedence, updates schema wording for plex_token, and adds tests/documentation.