### PR TITLE
fix(notifications): optional attribute state hygiene (#120)

### DIFF
--- a/internal/provider/notification_agent_schemas.go
+++ b/internal/provider/notification_agent_schemas.go
@@ -13,10 +13,10 @@ func notificationAgentResourceOptionAttributes() map[string]schema.Attribute {
 		"discord": schema.SingleNestedAttribute{
 			Optional: true,
 			Attributes: map[string]schema.Attribute{
-				"bot_username":    schema.StringAttribute{Optional: true},
-				"bot_avatar_url":  schema.StringAttribute{Optional: true},
+				"bot_username":    schema.StringAttribute{Optional: true, Computed: true},
+				"bot_avatar_url":  schema.StringAttribute{Optional: true, Computed: true},
 				"webhook_url":     schema.StringAttribute{Required: true},
-				"enable_mentions": schema.BoolAttribute{Optional: true},
+				"enable_mentions": schema.BoolAttribute{Optional: true, Computed: true},
 			},
 		},
 		"slack": schema.SingleNestedAttribute{
@@ -31,38 +31,38 @@ func notificationAgentResourceOptionAttributes() map[string]schema.Attribute {
 				"email_from":        schema.StringAttribute{Required: true},
 				"smtp_host":         schema.StringAttribute{Required: true},
 				"smtp_port":         schema.Int64Attribute{Required: true},
-				"secure":            schema.BoolAttribute{Optional: true},
-				"ignore_tls":        schema.BoolAttribute{Optional: true},
-				"require_tls":       schema.BoolAttribute{Optional: true},
-				"auth_user":         schema.StringAttribute{Optional: true},
-				"auth_pass":         schema.StringAttribute{Optional: true, Sensitive: true},
-				"allow_self_signed": schema.BoolAttribute{Optional: true},
+				"secure":            schema.BoolAttribute{Optional: true, Computed: true},
+				"ignore_tls":        schema.BoolAttribute{Optional: true, Computed: true},
+				"require_tls":       schema.BoolAttribute{Optional: true, Computed: true},
+				"auth_user":         schema.StringAttribute{Optional: true, Computed: true},
+				"auth_pass":         schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
+				"allow_self_signed": schema.BoolAttribute{Optional: true, Computed: true},
 				"sender_name":       schema.StringAttribute{Required: true},
-				"pgp_private_key":   schema.StringAttribute{Optional: true, Sensitive: true},
-				"pgp_password":      schema.StringAttribute{Optional: true, Sensitive: true},
+				"pgp_private_key":   schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
+				"pgp_password":      schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
 			},
 		},
 		"lunasea": schema.SingleNestedAttribute{
 			Optional: true,
 			Attributes: map[string]schema.Attribute{
 				"webhook_url":  schema.StringAttribute{Required: true},
-				"profile_name": schema.StringAttribute{Optional: true},
+				"profile_name": schema.StringAttribute{Optional: true, Computed: true},
 			},
 		},
 		"telegram": schema.SingleNestedAttribute{
 			Optional: true,
 			Attributes: map[string]schema.Attribute{
-				"bot_username":  schema.StringAttribute{Optional: true},
+				"bot_username":  schema.StringAttribute{Optional: true, Computed: true},
 				"bot_api":       schema.StringAttribute{Required: true, Sensitive: true},
 				"chat_id":       schema.StringAttribute{Required: true},
-				"send_silently": schema.BoolAttribute{Optional: true},
+				"send_silently": schema.BoolAttribute{Optional: true, Computed: true},
 			},
 		},
 		"pushbullet": schema.SingleNestedAttribute{
 			Optional: true,
 			Attributes: map[string]schema.Attribute{
 				"access_token": schema.StringAttribute{Required: true, Sensitive: true},
-				"channel_tag":  schema.StringAttribute{Optional: true},
+				"channel_tag":  schema.StringAttribute{Optional: true, Computed: true},
 			},
 		},
 		"pushover": schema.SingleNestedAttribute{
@@ -70,7 +70,7 @@ func notificationAgentResourceOptionAttributes() map[string]schema.Attribute {
 			Attributes: map[string]schema.Attribute{
 				"access_token": schema.StringAttribute{Required: true, Sensitive: true},
 				"user_token":   schema.StringAttribute{Required: true, Sensitive: true},
-				"sound":        schema.StringAttribute{Optional: true},
+				"sound":        schema.StringAttribute{Optional: true, Computed: true},
 			},
 		},
 		"ntfy": schema.SingleNestedAttribute{
@@ -78,12 +78,12 @@ func notificationAgentResourceOptionAttributes() map[string]schema.Attribute {
 			Attributes: map[string]schema.Attribute{
 				"url":                           schema.StringAttribute{Required: true},
 				"topic":                         schema.StringAttribute{Required: true},
-				"auth_method_username_password": schema.BoolAttribute{Optional: true},
-				"username":                      schema.StringAttribute{Optional: true},
-				"password":                      schema.StringAttribute{Optional: true, Sensitive: true},
-				"auth_method_token":             schema.BoolAttribute{Optional: true},
-				"token":                         schema.StringAttribute{Optional: true, Sensitive: true},
-				"priority":                      schema.Int64Attribute{Optional: true},
+				"auth_method_username_password": schema.BoolAttribute{Optional: true, Computed: true},
+				"username":                      schema.StringAttribute{Optional: true, Computed: true},
+				"password":                      schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
+				"auth_method_token":             schema.BoolAttribute{Optional: true, Computed: true},
+				"token":                         schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
+				"priority":                      schema.Int64Attribute{Optional: true, Computed: true},
 			},
 		},
 		"webhook": schema.SingleNestedAttribute{
@@ -91,7 +91,7 @@ func notificationAgentResourceOptionAttributes() map[string]schema.Attribute {
 			Attributes: map[string]schema.Attribute{
 				"webhook_url":  schema.StringAttribute{Required: true},
 				"json_payload": schema.StringAttribute{Required: true},
-				"auth_header":  schema.StringAttribute{Optional: true, Sensitive: true},
+				"auth_header":  schema.StringAttribute{Optional: true, Sensitive: true, Computed: true},
 			},
 		},
 		"gotify": schema.SingleNestedAttribute{

--- a/internal/provider/notification_client_state_test.go
+++ b/internal/provider/notification_client_state_test.go
@@ -2,12 +2,14 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -125,6 +127,114 @@ func assertPathNotRequested(t *testing.T, requested []string, unexpected path.Pa
 	for _, key := range requested {
 		if key == unexpectedKey {
 			t.Fatalf("did not expect path %q to be requested, got %v", unexpectedKey, requested)
+		}
+	}
+}
+
+func TestBuildPayloadNotificationOptionHygiene(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Case 1: Priority is Unknown (omitted in plan for Optional+Computed attribute)
+	modelUnknown := &NotificationAgentModel{
+		Agent:       types.StringValue("ntfy"),
+		Enabled:     types.BoolValue(true),
+		EmbedPoster: types.BoolValue(false),
+		Ntfy: &NotificationAgentNtfyModel{
+			Url:      types.StringValue("https://ntfy.example.com"),
+			Topic:    types.StringValue("test"),
+			Priority: types.Int64Unknown(),
+		},
+	}
+	payloadStr, err := buildPayload(ctx, modelUnknown)
+	if err != nil {
+		t.Fatalf("buildPayload failed: %v", err)
+	}
+	if reflect.ValueOf(payloadStr).Kind() == reflect.String && (reflect.ValueOf(payloadStr).Len() == 0 || (payloadStr != "" && (func() bool {
+		var m struct {
+			Options map[string]interface{} `json:"options"`
+		}
+		_ = json.Unmarshal([]byte(payloadStr), &m)
+		_, exists := m.Options["priority"]
+		return exists
+	})())) {
+		t.Fatalf("expected priority key to be omitted from payload options when unknown, got %s", payloadStr)
+	}
+
+	// Case 2: Priority is Null
+	modelNull := &NotificationAgentModel{
+		Agent:       types.StringValue("ntfy"),
+		Enabled:     types.BoolValue(true),
+		EmbedPoster: types.BoolValue(false),
+		Ntfy: &NotificationAgentNtfyModel{
+			Url:      types.StringValue("https://ntfy.example.com"),
+			Topic:    types.StringValue("test"),
+			Priority: types.Int64Null(),
+		},
+	}
+	payloadStrNull, err := buildPayload(ctx, modelNull)
+	if err != nil {
+		t.Fatalf("buildPayload failed: %v", err)
+	}
+	var mNull struct {
+		Options map[string]interface{} `json:"options"`
+	}
+	if err := json.Unmarshal([]byte(payloadStrNull), &mNull); err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+	if _, exists := mNull.Options["priority"]; exists {
+		t.Fatalf("expected priority key to be omitted from payload options when null, got %s", payloadStrNull)
+	}
+
+	// Case 3: Priority is explicitly set (e.g. 5)
+	modelSet := &NotificationAgentModel{
+		Agent:       types.StringValue("ntfy"),
+		Enabled:     types.BoolValue(true),
+		EmbedPoster: types.BoolValue(false),
+		Ntfy: &NotificationAgentNtfyModel{
+			Url:      types.StringValue("https://ntfy.example.com"),
+			Topic:    types.StringValue("test"),
+			Priority: types.Int64Value(5),
+		},
+	}
+	payloadStrSet, err := buildPayload(ctx, modelSet)
+	if err != nil {
+		t.Fatalf("buildPayload failed: %v", err)
+	}
+	var mSet struct {
+		Options map[string]interface{} `json:"options"`
+	}
+	if err := json.Unmarshal([]byte(payloadStrSet), &mSet); err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+	pVal, exists := mSet.Options["priority"]
+	if !exists || pVal != float64(5) {
+		t.Fatalf("expected priority key to be 5 in payload options, got %#v in %s", pVal, payloadStrSet)
+	}
+}
+
+func TestNotificationAgentSchemasOptionalComputedAudit(t *testing.T) {
+	t.Parallel()
+
+	options := notificationAgentResourceOptionAttributes()
+	for agentName, agentAttr := range options {
+		nested, ok := agentAttr.(schema.SingleNestedAttribute)
+		if !ok {
+			continue
+		}
+		for attrName, attr := range nested.Attributes {
+			isRequired := attr.IsRequired()
+			isComputed := attr.IsComputed()
+			isOptional := attr.IsOptional()
+
+			if !isRequired {
+				if !isOptional {
+					t.Errorf("agent %s attribute %s: expected Optional to be true", agentName, attrName)
+				}
+				if !isComputed {
+					t.Errorf("agent %s attribute %s: expected Computed to be true for state hygiene", agentName, attrName)
+				}
+			}
 		}
 	}
 }

--- a/internal/provider/resource_notification_agent.go
+++ b/internal/provider/resource_notification_agent.go
@@ -267,6 +267,18 @@ func setNotificationClientState(ctx context.Context, writer notificationAttribut
 	return diags
 }
 
+func isKnownNonNullString(v types.String) bool {
+	return !v.IsNull() && !v.IsUnknown()
+}
+
+func isKnownNonNullBool(v types.Bool) bool {
+	return !v.IsNull() && !v.IsUnknown()
+}
+
+func isKnownNonNullInt64(v types.Int64) bool {
+	return !v.IsNull() && !v.IsUnknown()
+}
+
 func buildPayload(ctx context.Context, data *NotificationAgentModel) (string, error) {
 	payload := notificationAgentPayload{
 		Enabled:     data.Enabled.ValueBool(),
@@ -278,154 +290,154 @@ func buildPayload(ctx context.Context, data *NotificationAgentModel) (string, er
 	switch data.Agent.ValueString() {
 	case "discord":
 		if data.Discord != nil {
-			if !data.Discord.BotUsername.IsNull() {
+			if isKnownNonNullString(data.Discord.BotUsername) {
 				payload.Options["botUsername"] = data.Discord.BotUsername.ValueString()
 			}
-			if !data.Discord.BotAvatarUrl.IsNull() {
+			if isKnownNonNullString(data.Discord.BotAvatarUrl) {
 				payload.Options["botAvatarUrl"] = data.Discord.BotAvatarUrl.ValueString()
 			}
-			if !data.Discord.WebhookUrl.IsNull() {
+			if isKnownNonNullString(data.Discord.WebhookUrl) {
 				payload.Options["webhookUrl"] = data.Discord.WebhookUrl.ValueString()
 			}
-			if !data.Discord.EnableMentions.IsNull() {
+			if isKnownNonNullBool(data.Discord.EnableMentions) {
 				payload.Options["enableMentions"] = data.Discord.EnableMentions.ValueBool()
 			}
 		}
 	case "slack":
 		if data.Slack != nil {
-			if !data.Slack.WebhookUrl.IsNull() {
+			if isKnownNonNullString(data.Slack.WebhookUrl) {
 				payload.Options["webhookUrl"] = data.Slack.WebhookUrl.ValueString()
 			}
 		}
 	case "email":
 		if data.Email != nil {
-			if !data.Email.EmailFrom.IsNull() {
+			if isKnownNonNullString(data.Email.EmailFrom) {
 				payload.Options["emailFrom"] = data.Email.EmailFrom.ValueString()
 			}
-			if !data.Email.SmtpHost.IsNull() {
+			if isKnownNonNullString(data.Email.SmtpHost) {
 				payload.Options["smtpHost"] = data.Email.SmtpHost.ValueString()
 			}
-			if !data.Email.SmtpPort.IsNull() {
+			if isKnownNonNullInt64(data.Email.SmtpPort) {
 				payload.Options["smtpPort"] = data.Email.SmtpPort.ValueInt64()
 			}
-			if !data.Email.Secure.IsNull() {
+			if isKnownNonNullBool(data.Email.Secure) {
 				payload.Options["secure"] = data.Email.Secure.ValueBool()
 			}
-			if !data.Email.IgnoreTls.IsNull() {
+			if isKnownNonNullBool(data.Email.IgnoreTls) {
 				payload.Options["ignoreTls"] = data.Email.IgnoreTls.ValueBool()
 			}
-			if !data.Email.RequireTls.IsNull() {
+			if isKnownNonNullBool(data.Email.RequireTls) {
 				payload.Options["requireTls"] = data.Email.RequireTls.ValueBool()
 			}
-			if !data.Email.AuthUser.IsNull() {
+			if isKnownNonNullString(data.Email.AuthUser) {
 				payload.Options["authUser"] = data.Email.AuthUser.ValueString()
 			}
-			if !data.Email.AuthPass.IsNull() {
+			if isKnownNonNullString(data.Email.AuthPass) {
 				payload.Options["authPass"] = data.Email.AuthPass.ValueString()
 			}
-			if !data.Email.AllowSelfSigned.IsNull() {
+			if isKnownNonNullBool(data.Email.AllowSelfSigned) {
 				payload.Options["allowSelfSigned"] = data.Email.AllowSelfSigned.ValueBool()
 			}
-			if !data.Email.SenderName.IsNull() {
+			if isKnownNonNullString(data.Email.SenderName) {
 				payload.Options["senderName"] = data.Email.SenderName.ValueString()
 			}
-			if !data.Email.PgpPrivateKey.IsNull() {
+			if isKnownNonNullString(data.Email.PgpPrivateKey) {
 				payload.Options["pgpPrivateKey"] = data.Email.PgpPrivateKey.ValueString()
 			}
-			if !data.Email.PgpPassword.IsNull() {
+			if isKnownNonNullString(data.Email.PgpPassword) {
 				payload.Options["pgpPassword"] = data.Email.PgpPassword.ValueString()
 			}
 		}
 	case "lunasea":
 		if data.LunaSea != nil {
-			if !data.LunaSea.WebhookUrl.IsNull() {
+			if isKnownNonNullString(data.LunaSea.WebhookUrl) {
 				payload.Options["webhookUrl"] = data.LunaSea.WebhookUrl.ValueString()
 			}
-			if !data.LunaSea.ProfileName.IsNull() {
+			if isKnownNonNullString(data.LunaSea.ProfileName) {
 				payload.Options["profileName"] = data.LunaSea.ProfileName.ValueString()
 			}
 		}
 	case "telegram":
 		if data.Telegram != nil {
-			if !data.Telegram.BotUsername.IsNull() {
+			if isKnownNonNullString(data.Telegram.BotUsername) {
 				payload.Options["botUsername"] = data.Telegram.BotUsername.ValueString()
 			}
-			if !data.Telegram.BotAPI.IsNull() {
+			if isKnownNonNullString(data.Telegram.BotAPI) {
 				payload.Options["botAPI"] = data.Telegram.BotAPI.ValueString()
 			}
-			if !data.Telegram.ChatId.IsNull() {
+			if isKnownNonNullString(data.Telegram.ChatId) {
 				payload.Options["chatId"] = data.Telegram.ChatId.ValueString()
 			}
-			if !data.Telegram.SendSilently.IsNull() {
+			if isKnownNonNullBool(data.Telegram.SendSilently) {
 				payload.Options["sendSilently"] = data.Telegram.SendSilently.ValueBool()
 			}
 		}
 	case "pushbullet":
 		if data.Pushbullet != nil {
-			if !data.Pushbullet.AccessToken.IsNull() {
+			if isKnownNonNullString(data.Pushbullet.AccessToken) {
 				payload.Options["accessToken"] = data.Pushbullet.AccessToken.ValueString()
 			}
-			if !data.Pushbullet.ChannelTag.IsNull() {
+			if isKnownNonNullString(data.Pushbullet.ChannelTag) {
 				payload.Options["channelTag"] = data.Pushbullet.ChannelTag.ValueString()
 			}
 		}
 	case "pushover":
 		if data.Pushover != nil {
-			if !data.Pushover.AccessToken.IsNull() {
+			if isKnownNonNullString(data.Pushover.AccessToken) {
 				payload.Options["accessToken"] = data.Pushover.AccessToken.ValueString()
 			}
-			if !data.Pushover.UserToken.IsNull() {
+			if isKnownNonNullString(data.Pushover.UserToken) {
 				payload.Options["userToken"] = data.Pushover.UserToken.ValueString()
 			}
-			if !data.Pushover.Sound.IsNull() {
+			if isKnownNonNullString(data.Pushover.Sound) {
 				payload.Options["sound"] = data.Pushover.Sound.ValueString()
 			}
 		}
 	case "ntfy":
 		if data.Ntfy != nil {
-			if !data.Ntfy.Url.IsNull() {
+			if isKnownNonNullString(data.Ntfy.Url) {
 				payload.Options["url"] = data.Ntfy.Url.ValueString()
 			}
-			if !data.Ntfy.Topic.IsNull() {
+			if isKnownNonNullString(data.Ntfy.Topic) {
 				payload.Options["topic"] = data.Ntfy.Topic.ValueString()
 			}
-			if !data.Ntfy.AuthMethodUsernamePassword.IsNull() {
+			if isKnownNonNullBool(data.Ntfy.AuthMethodUsernamePassword) {
 				payload.Options["authMethodUsernamePassword"] = data.Ntfy.AuthMethodUsernamePassword.ValueBool()
 			}
-			if !data.Ntfy.Username.IsNull() {
+			if isKnownNonNullString(data.Ntfy.Username) {
 				payload.Options["username"] = data.Ntfy.Username.ValueString()
 			}
-			if !data.Ntfy.Password.IsNull() {
+			if isKnownNonNullString(data.Ntfy.Password) {
 				payload.Options["password"] = data.Ntfy.Password.ValueString()
 			}
-			if !data.Ntfy.AuthMethodToken.IsNull() {
+			if isKnownNonNullBool(data.Ntfy.AuthMethodToken) {
 				payload.Options["authMethodToken"] = data.Ntfy.AuthMethodToken.ValueBool()
 			}
-			if !data.Ntfy.Token.IsNull() {
+			if isKnownNonNullString(data.Ntfy.Token) {
 				payload.Options["token"] = data.Ntfy.Token.ValueString()
 			}
-			if !data.Ntfy.Priority.IsNull() {
+			if isKnownNonNullInt64(data.Ntfy.Priority) {
 				payload.Options["priority"] = data.Ntfy.Priority.ValueInt64()
 			}
 		}
 	case "webhook":
 		if data.Webhook != nil {
-			if !data.Webhook.WebhookUrl.IsNull() {
+			if isKnownNonNullString(data.Webhook.WebhookUrl) {
 				payload.Options["webhookUrl"] = data.Webhook.WebhookUrl.ValueString()
 			}
-			if !data.Webhook.JsonPayload.IsNull() {
+			if isKnownNonNullString(data.Webhook.JsonPayload) {
 				payload.Options["jsonPayload"] = data.Webhook.JsonPayload.ValueString()
 			}
-			if !data.Webhook.AuthHeader.IsNull() {
+			if isKnownNonNullString(data.Webhook.AuthHeader) {
 				payload.Options["authHeader"] = data.Webhook.AuthHeader.ValueString()
 			}
 		}
 	case "gotify":
 		if data.Gotify != nil {
-			if !data.Gotify.Url.IsNull() {
+			if isKnownNonNullString(data.Gotify.Url) {
 				payload.Options["url"] = data.Gotify.Url.ValueString()
 			}
-			if !data.Gotify.Token.IsNull() {
+			if isKnownNonNullString(data.Gotify.Token) {
 				payload.Options["token"] = data.Gotify.Token.ValueString()
 			}
 		}


### PR DESCRIPTION
### Summary
- Updated optional nested attributes in 
otificationAgentResourceOptionAttributes() across all notification agents (e.g. 
tfy.priority, pushover.sound, discord.bot_username, etc.) to be Optional: true, Computed: true.
- Updated uildPayload in esource_notification_agent.go using helper functions (isKnownNonNullString, isKnownNonNullBool, isKnownNonNullInt64) so option keys are ONLY sent when explicitly set in config (known and non-null).
- Added schema audit unit tests ensuring all optional nested notification attributes have Computed: true.
- Added unit tests for uildPayload verifying option key omission for null/unknown values vs inclusion when set.

### Test plan
- Ran go test -v ./internal/provider/... - all unit tests pass.
- Verified schema audit test TestNotificationAgentSchemasOptionalComputedAudit.
- Verified payload hygiene test TestBuildPayloadNotificationOptionHygiene.

Closes #120