### PR TITLE
fix(plex_library_settings): omit empty enable query parameter

### DIFF
--- a/docs/openapi-coverage.md
+++ b/docs/openapi-coverage.md
@@ -6,9 +6,9 @@ Inventory of Seerr OpenAPI endpoints classified by Terraform provider support an
 
 - **Total OpenAPI Paths**: 163
 - **Total Endpoints (Methods)**: 212
-- **Covered Paths**: 51 (31.3%)
+- **Covered Paths**: 54 (33.1%)
 - **Intentionally Out of Scope**: 106 (65.0%)
-- **Uncovered Settings/User Backlog**: 6 (3.7%)
+- **Uncovered Settings/User Backlog**: 3 (1.8%)
 
 ## Classification Legend
 
@@ -160,14 +160,14 @@ Inventory of Seerr OpenAPI endpoints classified by Terraform provider support an
 | `/tv/{tvId}/season/{seasonNumber}` | GET | `intentionally-out-of-scope` | TMDB TV season details |
 | `/tv/{tvId}/similar` | GET | `intentionally-out-of-scope` | TMDB TV similar query |
 | `/user` | GET, POST, PUT | `covered` | `seerr_user` - User list/create resource & data source |
-| `/user/import-from-jellyfin` | POST | `uncovered` | Jellyfin user import action (Issue #124 candidate) |
-| `/user/import-from-plex` | POST | `uncovered` | Plex user import action (Issue #124 candidate) |
+| `/user/import-from-jellyfin` | POST | `covered` | `seerr_user_import_jellyfin` - Jellyfin user import resource & data source |
+| `/user/import-from-plex` | POST | `covered` | `seerr_user_import_plex` - Plex user import resource & data source |
 | `/user/jellyfin/{jellyfinUserId}` | GET | `intentionally-out-of-scope` | Jellyfin user lookup |
 | `/user/registerPushSubscription` | POST | `intentionally-out-of-scope` | Browser push notification registration |
 | `/user/{userId}` | DELETE, GET, PUT | `covered` | `seerr_user` - User resource & data source |
 | `/user/{userId}/pushSubscription/{endpoint}` | DELETE, GET | `intentionally-out-of-scope` | Browser push notification item |
 | `/user/{userId}/pushSubscriptions` | GET | `intentionally-out-of-scope` | Browser push notifications list |
-| `/user/{userId}/quota` | GET | `uncovered` | User quota settings (Issue #122 candidate) |
+| `/user/{userId}/quota` | GET | `covered` | `seerr_user_quota` - User quota resource & data source |
 | `/user/{userId}/requests` | GET | `intentionally-out-of-scope` | Per-user request history query endpoint |
 | `/user/{userId}/settings/linked-accounts/jellyfin` | DELETE, POST | `intentionally-out-of-scope` | Jellyfin account linking |
 | `/user/{userId}/settings/linked-accounts/jellyfin/quickconnect` | POST | `intentionally-out-of-scope` | Jellyfin QuickConnect linking |

--- a/internal/provider/resource_plex_library_settings.go
+++ b/internal/provider/resource_plex_library_settings.go
@@ -168,15 +168,17 @@ func (r *PlexLibrarySettingsResource) updatePlexLibraries(ctx context.Context, d
 		}
 	}
 
-	enableQuery := ""
-	for i, id := range enabledList {
-		if i > 0 {
-			enableQuery += ","
+	apiPath := "/api/v1/settings/plex/library"
+	if len(enabledList) > 0 {
+		enableQuery := ""
+		for i, id := range enabledList {
+			if i > 0 {
+				enableQuery += ","
+			}
+			enableQuery += id
 		}
-		enableQuery += id
+		apiPath = fmt.Sprintf("/api/v1/settings/plex/library?enable=%s", enableQuery)
 	}
-
-	apiPath := fmt.Sprintf("/api/v1/settings/plex/library?enable=%s", enableQuery)
 	res, err := r.client.Request(ctx, "GET", apiPath, "", nil)
 	if err != nil {
 		return err

--- a/internal/provider/resource_plex_library_settings_test.go
+++ b/internal/provider/resource_plex_library_settings_test.go
@@ -49,3 +49,27 @@ func TestPlexLibrarySettingsParseResponse(t *testing.T) {
 	require.False(t, diags.HasError())
 	assert.ElementsMatch(t, []string{"1", "2"}, enabled)
 }
+
+func TestPlexLibrarySettingsEmptyEnabledLibraries(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/settings/plex/library", r.URL.Path)
+		assert.Empty(t, r.URL.Query().Get("enable"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer mockServer.Close()
+
+	baseURL, err := url.Parse(mockServer.URL)
+	require.NoError(t, err)
+
+	client := NewClient(baseURL, "test-api-key", "test-agent", false, defaultRequestTimeout)
+	res := &PlexLibrarySettingsResource{client: client}
+
+	ctx := context.Background()
+	var data PlexLibrarySettingsModel
+	data.EnabledLibraries, _ = types.SetValueFrom(ctx, types.StringType, []string{})
+
+	err = res.updatePlexLibraries(ctx, &data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes status 400 error when enabling zero Plex libraries.