### PR TITLE
feat: expand jellyfin settings and library parity

### DIFF
--- a/docs/data-sources/jellyfin_settings.md
+++ b/docs/data-sources/jellyfin_settings.md
@@ -25,6 +25,7 @@ output "jellyfin_url_base" {
 
 ### Read-Only
 
+- `api_key` (String, Sensitive) The API key for the Jellyfin server.
 - `external_hostname` (String) The external hostname for the Jellyfin server.
 - `id` (String) The ID of this resource.
 - `ip` (String) The IP address or hostname of the Jellyfin server.

--- a/internal/provider/data_source_jellyfin_library_settings.go
+++ b/internal/provider/data_source_jellyfin_library_settings.go
@@ -107,8 +107,8 @@ func (d *JellyfinLibrarySettingsDataSource) Read(ctx context.Context, req dataso
 		return
 	}
 
-	var libModels []JellyfinLibraryModel
-	var enabledIDs []string
+	libModels := make([]JellyfinLibraryModel, 0, len(rawLibs))
+	enabledIDs := make([]string, 0)
 
 	for _, l := range rawLibs {
 		idStr := fmt.Sprintf("%v", l.ID)

--- a/internal/provider/data_source_jellyfin_settings.go
+++ b/internal/provider/data_source_jellyfin_settings.go
@@ -26,6 +26,7 @@ type JellyfinSettingsDataSourceModel struct {
 	ExternalHostname          types.String `tfsdk:"external_hostname"`
 	JellyfinForgotPasswordURL types.String `tfsdk:"jellyfin_forgot_password_url"`
 	ServerID                  types.String `tfsdk:"server_id"`
+	APIKey                    types.String `tfsdk:"api_key"`
 	ResponseJSON              types.String `tfsdk:"response_json"`
 	StatusCode                types.Int64  `tfsdk:"status_code"`
 }
@@ -70,6 +71,11 @@ func (d *JellyfinSettingsDataSource) Schema(_ context.Context, _ datasource.Sche
 			"jellyfin_forgot_password_url": schema.StringAttribute{
 				MarkdownDescription: "The URL for forgotten passwords on the Jellyfin server.",
 				Computed:            true,
+			},
+			"api_key": schema.StringAttribute{
+				MarkdownDescription: "The API key for the Jellyfin server.",
+				Computed:            true,
+				Sensitive:           true,
 			},
 			"server_id": schema.StringAttribute{
 				MarkdownDescription: "The unique server ID of the connected Jellyfin server.",
@@ -145,6 +151,9 @@ func (d *JellyfinSettingsDataSource) Read(ctx context.Context, req datasource.Re
 	}
 	if v, ok := decoded["jellyfinForgotPasswordUrl"].(string); ok {
 		data.JellyfinForgotPasswordURL = types.StringValue(v)
+	}
+	if v, ok := decoded["apiKey"].(string); ok && v != "" {
+		data.APIKey = types.StringValue(v)
 	}
 	if v, ok := decoded["serverId"].(string); ok {
 		data.ServerID = types.StringValue(v)

--- a/internal/provider/data_source_jellyfin_settings_test.go
+++ b/internal/provider/data_source_jellyfin_settings_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJellyfinSettingsDataSourceRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/settings/jellyfin", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"name": "Jellyfin",
+			"ip": "192.168.1.100",
+			"port": 8096,
+			"useSsl": false,
+			"urlBase": "/jellyfin",
+			"externalHostname": "jellyfin.example.com",
+			"jellyfinForgotPasswordUrl": "https://jellyfin.example.com/forgot",
+			"apiKey": "mock-jellyfin-key-123",
+			"serverId": "jf-server-uuid-123"
+		}`))
+	}))
+	defer srv.Close()
+
+	baseURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	d := &JellyfinSettingsDataSource{
+		client: NewClient(baseURL, "test-api-key", "test-agent", false, defaultRequestTimeout),
+	}
+
+	res, err := d.client.Request(context.Background(), "GET", "/api/v1/settings/jellyfin", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var decoded map[string]any
+	err = json.Unmarshal(res.Body, &decoded)
+	require.NoError(t, err)
+
+	data := JellyfinSettingsDataSourceModel{}
+	data.StatusCode = types.Int64Value(int64(res.StatusCode))
+	data.ResponseJSON = types.StringValue(string(res.Body))
+
+	if v, ok := decoded["name"].(string); ok {
+		data.Name = types.StringValue(v)
+	}
+	if v, ok := decoded["ip"].(string); ok {
+		data.IP = types.StringValue(v)
+	}
+	if v, ok := decoded["port"].(float64); ok {
+		data.Port = types.Int64Value(int64(v))
+	}
+	if v, ok := decoded["useSsl"].(bool); ok {
+		data.UseSSL = types.BoolValue(v)
+	}
+	if v, ok := decoded["urlBase"].(string); ok {
+		data.URLBase = types.StringValue(v)
+	}
+	if v, ok := decoded["externalHostname"].(string); ok {
+		data.ExternalHostname = types.StringValue(v)
+	}
+	if v, ok := decoded["jellyfinForgotPasswordUrl"].(string); ok {
+		data.JellyfinForgotPasswordURL = types.StringValue(v)
+	}
+	if v, ok := decoded["apiKey"].(string); ok && v != "" {
+		data.APIKey = types.StringValue(v)
+	}
+	if v, ok := decoded["serverId"].(string); ok {
+		data.ServerID = types.StringValue(v)
+	}
+	data.ID = types.StringValue("jellyfin")
+
+	assert.Equal(t, "Jellyfin", data.Name.ValueString())
+	assert.Equal(t, "192.168.1.100", data.IP.ValueString())
+	assert.Equal(t, int64(8096), data.Port.ValueInt64())
+	assert.False(t, data.UseSSL.ValueBool())
+	assert.Equal(t, "/jellyfin", data.URLBase.ValueString())
+	assert.Equal(t, "jellyfin.example.com", data.ExternalHostname.ValueString())
+	assert.Equal(t, "https://jellyfin.example.com/forgot", data.JellyfinForgotPasswordURL.ValueString())
+	assert.Equal(t, "mock-jellyfin-key-123", data.APIKey.ValueString())
+	assert.Equal(t, "jf-server-uuid-123", data.ServerID.ValueString())
+	assert.Equal(t, "jellyfin", data.ID.ValueString())
+}


### PR DESCRIPTION
Implements seerr_jellyfin_settings data source matching resource schema, enhances Jellyfin library settings and sync resources with typed enable lists and sync triggers matching Emby/Plex pattern, adds unit tests and updates docs.