### PR TITLE
fix(lint): resolve golangci-lint issues to pass CI

### DIFF
--- a/internal/provider/client_retry_test.go
+++ b/internal/provider/client_retry_test.go
@@ -164,7 +164,7 @@ func TestClientRetryAfterCappedAt60Seconds(t *testing.T) {
 
 func TestParseRetryAfterSeconds(t *testing.T) {
 	assert.Equal(t, 5*time.Second, parseRetryAfter("5"))
-	assert.Equal(t, time.Duration(1500*time.Millisecond), parseRetryAfter("1.5"))
+	assert.Equal(t, 1500*time.Millisecond, parseRetryAfter("1.5"))
 	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
 	assert.Equal(t, time.Duration(0), parseRetryAfter("-1"))
 }

--- a/internal/provider/data_source_email_settings_test.go
+++ b/internal/provider/data_source_email_settings_test.go
@@ -72,7 +72,8 @@ func TestEmailSettingsDataSourceRead(t *testing.T) {
 
 	client := NewClient(baseURL, "test-api-key", "test-agent", false, defaultRequestTimeout)
 
-	ds := newNotificationClientDataSourceWithTypeName("email", "email_settings").(*NotificationClientDataSource)
+	ds, ok := newNotificationClientDataSourceWithTypeName("email", "email_settings").(*NotificationClientDataSource)
+	require.True(t, ok)
 	ds.client = client
 
 	res, err := ds.client.Request(context.Background(), "GET", notificationPath("email"), "", nil)

--- a/internal/provider/data_source_pushbullet_settings_test.go
+++ b/internal/provider/data_source_pushbullet_settings_test.go
@@ -62,7 +62,8 @@ func TestPushbulletSettingsDataSourceRead(t *testing.T) {
 
 	client := NewClient(baseURL, "test-api-key", "test-agent", false, defaultRequestTimeout)
 
-	ds := newNotificationClientDataSourceWithTypeName("pushbullet", "pushbullet_settings").(*NotificationClientDataSource)
+	ds, ok := newNotificationClientDataSourceWithTypeName("pushbullet", "pushbullet_settings").(*NotificationClientDataSource)
+	require.True(t, ok)
 	ds.client = client
 
 	res, err := ds.client.Request(context.Background(), "GET", notificationPath("pushbullet"), "", nil)

--- a/internal/provider/pagination.go
+++ b/internal/provider/pagination.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/url"
 	"strconv"
 	"strings"
 )
-
-const maxInt = math.MaxInt
 
 // defaultPaginationPageSize is used when auto-fetching all pages from Seerr list endpoints.
 // Prefer a moderate size over a large hard-coded take so servers are not overloaded.
@@ -164,10 +161,7 @@ func shouldStopPagination(info pageInfo, pageLen, pageSize, totalFetched int) bo
 
 	// 2. If server pagination metadata has page and pages (without total):
 	if info.hasPage && info.hasPages && info.page > 0 && info.pages > 0 {
-		if info.page >= info.pages {
-			return true
-		}
-		return false
+		return info.page >= info.pages
 	}
 
 	// 3. Fallback heuristic (no usable pageInfo metadata available):

--- a/internal/provider/resource_user_notification_settings.go
+++ b/internal/provider/resource_user_notification_settings.go
@@ -440,6 +440,9 @@ func populateUserNotificationSettingsFromMap(
 }
 
 func buildUserNotificationSettingsPayload(ctx context.Context, client *APIClient, userID int64, data *UserNotificationSettingsResourceModel) (map[string]any, error) {
+	if client == nil {
+		return nil, fmt.Errorf("API client is nil")
+	}
 	apiPath := userNotificationSettingsPath(userID)
 	res, err := client.Request(ctx, "GET", apiPath, "", nil)
 	var current map[string]any

--- a/tools/openapi/coverage.go
+++ b/tools/openapi/coverage.go
@@ -280,6 +280,9 @@ func ParseOpenAPISpec(filePath string) (*OpenAPISpec, error) {
 
 // AnalyzeCoverage checks all paths in spec against rules.
 func AnalyzeCoverage(spec *OpenAPISpec, rules []PathRule) (*CoverageReport, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("spec is nil")
+	}
 	ruleMap := make(map[string]PathRule)
 	for _, r := range rules {
 		ruleMap[r.PathPattern] = r


### PR DESCRIPTION
Resolves all 7 golangci-lint issues (unused const, type assertions, staticcheck boolean returns, unconvert, and unparam) to fix CI.