### PR TITLE
fix: validate v0.31 examples and schema contracts

### DIFF
--- a/docs/resources/emby_library_settings.md
+++ b/docs/resources/emby_library_settings.md
@@ -14,7 +14,7 @@ Manage Emby library enable/disable settings via `/api/v1/settings/emby/library`.
 
 ```terraform
 resource "seerr_emby_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }
 ```
 

--- a/docs/resources/jellyfin_library_settings.md
+++ b/docs/resources/jellyfin_library_settings.md
@@ -14,7 +14,7 @@ Manage Jellyfin library enable/disable settings via `/api/v1/settings/jellyfin/l
 
 ```terraform
 resource "seerr_jellyfin_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }
 ```
 

--- a/docs/resources/job_run.md
+++ b/docs/resources/job_run.md
@@ -14,7 +14,7 @@ Trigger an operational job execution via `/api/v1/settings/jobs/{jobId}/run`. Op
 
 ```terraform
 resource "seerr_job_run" "example" {
-  # Add your configuration here
+  job_id = "plex-sync"
 }
 ```
 

--- a/docs/resources/plex_library_settings.md
+++ b/docs/resources/plex_library_settings.md
@@ -14,7 +14,7 @@ Manage Plex library enable/disable settings via `/api/v1/settings/plex/library`.
 
 ```terraform
 resource "seerr_plex_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }
 ```
 

--- a/examples/resources/seerr_emby_library_settings/resource.tf
+++ b/examples/resources/seerr_emby_library_settings/resource.tf
@@ -1,3 +1,3 @@
 resource "seerr_emby_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }

--- a/examples/resources/seerr_jellyfin_library_settings/resource.tf
+++ b/examples/resources/seerr_jellyfin_library_settings/resource.tf
@@ -1,3 +1,3 @@
 resource "seerr_jellyfin_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }

--- a/examples/resources/seerr_job_run/resource.tf
+++ b/examples/resources/seerr_job_run/resource.tf
@@ -1,3 +1,3 @@
 resource "seerr_job_run" "example" {
-  # Add your configuration here
+  job_id = "plex-sync"
 }

--- a/examples/resources/seerr_plex_library_settings/resource.tf
+++ b/examples/resources/seerr_plex_library_settings/resource.tf
@@ -1,3 +1,3 @@
 resource "seerr_plex_library_settings" "example" {
-  # Add your configuration here
+  enabled_libraries = ["<library-id>"]
 }

--- a/internal/provider/resource_api_object_test.go
+++ b/internal/provider/resource_api_object_test.go
@@ -1,22 +1,22 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestAPIObjectResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewAPIObjectResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewAPIObjectResource(), map[string]resourceAttributeContract{
+		"id":                 computedString,
+		"path":               requiredString,
+		"headers":            optionalMap,
+		"request_body_json":  optionalString,
+		"delete_body_json":   optionalString,
+		"read_method":        optionalComputedString,
+		"create_method":      optionalComputedString,
+		"update_method":      optionalComputedString,
+		"delete_method":      optionalComputedString,
+		"skip_delete":        optionalComputedBool,
+		"suppress_not_found": optionalComputedBool,
+		"response_body_json": computedString,
+		"status_code":        computedInt64,
+	}, nil)
 }

--- a/internal/provider/resource_blocklist_test.go
+++ b/internal/provider/resource_blocklist_test.go
@@ -1,22 +1,16 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestBlocklistResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewBlocklistResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewBlocklistResource(), map[string]resourceAttributeContract{
+		"id":               computedString,
+		"tmdb_id":          requiredInt64,
+		"media_type":       requiredString,
+		"title":            optionalComputedString,
+		"user_id":          requiredInt64,
+		"blocklisted_tags": optionalComputedString,
+		"created_at":       computedString,
+	}, nil)
 }

--- a/internal/provider/resource_emby_settings_test.go
+++ b/internal/provider/resource_emby_settings_test.go
@@ -1,22 +1,21 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestEmbySettingsResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewEmbySettingsResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewEmbySettingsResource(), map[string]resourceAttributeContract{
+		"id":                       computedString,
+		"name":                     optionalComputedString,
+		"ip":                       requiredString,
+		"port":                     requiredInt64,
+		"use_ssl":                  optionalComputedBool,
+		"url_base":                 optionalComputedString,
+		"external_hostname":        optionalComputedString,
+		"emby_forgot_password_url": optionalComputedString,
+		"api_key":                  requiredSensitiveString,
+		"server_id":                computedString,
+		"response_json":            computedString,
+		"status_code":              computedInt64,
+	}, nil)
 }

--- a/internal/provider/resource_jellyfin_settings_test.go
+++ b/internal/provider/resource_jellyfin_settings_test.go
@@ -1,22 +1,21 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestJellyfinSettingsResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewJellyfinSettingsResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewJellyfinSettingsResource(), map[string]resourceAttributeContract{
+		"id":                           computedString,
+		"name":                         optionalComputedString,
+		"ip":                           requiredString,
+		"port":                         requiredInt64,
+		"use_ssl":                      optionalComputedBool,
+		"url_base":                     optionalComputedString,
+		"external_hostname":            optionalComputedString,
+		"jellyfin_forgot_password_url": optionalComputedString,
+		"api_key":                      requiredSensitiveString,
+		"server_id":                    computedString,
+		"response_json":                computedString,
+		"status_code":                  computedInt64,
+	}, nil)
 }

--- a/internal/provider/resource_network_settings_test.go
+++ b/internal/provider/resource_network_settings_test.go
@@ -1,22 +1,17 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestNetworkSettingsResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewNetworkSettingsResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewNetworkSettingsResource(), map[string]resourceAttributeContract{
+		"id":                     computedString,
+		"csrf_protection":        optionalComputedBool,
+		"force_ipv4_first":       optionalComputedBool,
+		"trust_proxy":            optionalComputedBool,
+		"api_request_timeout_ms": optionalComputedInt64,
+	}, map[string][]string{
+		"proxy":     {"enabled", "hostname", "port", "use_ssl", "user", "password", "bypass_filter", "bypass_local_addresses"},
+		"dns_cache": {"enabled", "force_min_ttl", "force_max_ttl"},
+	})
 }

--- a/internal/provider/resource_override_rule_test.go
+++ b/internal/provider/resource_override_rule_test.go
@@ -1,22 +1,21 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestOverrideRuleResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewOverrideRuleResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewOverrideRuleResource(), map[string]resourceAttributeContract{
+		"id":                computedString,
+		"users":             optionalComputedString,
+		"genre":             optionalComputedString,
+		"language":          optionalComputedString,
+		"keywords":          optionalComputedString,
+		"profile_id":        optionalComputedInt64,
+		"root_folder":       optionalComputedString,
+		"tags":              optionalComputedString,
+		"radarr_service_id": optionalComputedInt64,
+		"sonarr_service_id": optionalComputedInt64,
+		"created_at":        computedString,
+		"updated_at":        computedString,
+	}, nil)
 }

--- a/internal/provider/resource_schema_contract_test.go
+++ b/internal/provider/resource_schema_contract_test.go
@@ -1,0 +1,114 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+type resourceAttributeContract struct {
+	kind      string
+	required  bool
+	optional  bool
+	computed  bool
+	sensitive bool
+}
+
+var (
+	requiredString          = resourceAttributeContract{kind: "string", required: true}
+	requiredInt64           = resourceAttributeContract{kind: "int64", required: true}
+	requiredSensitiveString = resourceAttributeContract{kind: "string", required: true, sensitive: true}
+	optionalString          = resourceAttributeContract{kind: "string", optional: true}
+	optionalMap             = resourceAttributeContract{kind: "map", optional: true}
+	optionalSensitiveString = resourceAttributeContract{kind: "string", optional: true, sensitive: true}
+	optionalComputedString  = resourceAttributeContract{kind: "string", optional: true, computed: true}
+	optionalComputedInt64   = resourceAttributeContract{kind: "int64", optional: true, computed: true}
+	optionalComputedBool    = resourceAttributeContract{kind: "bool", optional: true, computed: true}
+	computedString          = resourceAttributeContract{kind: "string", computed: true}
+	computedInt64           = resourceAttributeContract{kind: "int64", computed: true}
+)
+
+func assertResourceSchemaContract(
+	t *testing.T,
+	r resource.Resource,
+	wantAttributes map[string]resourceAttributeContract,
+	wantBlocks map[string][]string,
+) {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
+	}
+
+	if len(resp.Schema.Attributes) != len(wantAttributes) {
+		t.Errorf("Schema() returned %d attributes; want %d", len(resp.Schema.Attributes), len(wantAttributes))
+	}
+	for name, want := range wantAttributes {
+		got, ok := resp.Schema.Attributes[name]
+		if !ok {
+			t.Errorf("Schema() missing attribute %q", name)
+			continue
+		}
+
+		if kind := resourceAttributeKind(got); kind != want.kind {
+			t.Errorf("attribute %q kind = %q; want %q", name, kind, want.kind)
+		}
+		if got.IsRequired() != want.required {
+			t.Errorf("attribute %q required = %t; want %t", name, got.IsRequired(), want.required)
+		}
+		if got.IsOptional() != want.optional {
+			t.Errorf("attribute %q optional = %t; want %t", name, got.IsOptional(), want.optional)
+		}
+		if got.IsComputed() != want.computed {
+			t.Errorf("attribute %q computed = %t; want %t", name, got.IsComputed(), want.computed)
+		}
+		if got.IsSensitive() != want.sensitive {
+			t.Errorf("attribute %q sensitive = %t; want %t", name, got.IsSensitive(), want.sensitive)
+		}
+	}
+
+	if len(resp.Schema.Blocks) != len(wantBlocks) {
+		t.Errorf("Schema() returned %d blocks; want %d", len(resp.Schema.Blocks), len(wantBlocks))
+	}
+	for name, wantNestedAttributes := range wantBlocks {
+		got, ok := resp.Schema.Blocks[name]
+		if !ok {
+			t.Errorf("Schema() missing block %q", name)
+			continue
+		}
+
+		single, ok := got.(schema.SingleNestedBlock)
+		if !ok {
+			t.Errorf("block %q type = %T; want schema.SingleNestedBlock", name, got)
+			continue
+		}
+		if len(single.Attributes) != len(wantNestedAttributes) {
+			t.Errorf("block %q returned %d attributes; want %d", name, len(single.Attributes), len(wantNestedAttributes))
+		}
+		for _, nestedName := range wantNestedAttributes {
+			if _, ok := single.Attributes[nestedName]; !ok {
+				t.Errorf("block %q missing attribute %q", name, nestedName)
+			}
+		}
+	}
+}
+
+func resourceAttributeKind(attribute schema.Attribute) string {
+	switch attribute.(type) {
+	case schema.BoolAttribute:
+		return "bool"
+	case schema.Int64Attribute:
+		return "int64"
+	case schema.MapAttribute:
+		return "map"
+	case schema.StringAttribute:
+		return "string"
+	default:
+		return fmt.Sprintf("%T", attribute)
+	}
+}

--- a/internal/provider/resource_tautulli_settings_test.go
+++ b/internal/provider/resource_tautulli_settings_test.go
@@ -1,22 +1,19 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestTautulliSettingsResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewTautulliSettingsResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewTautulliSettingsResource(), map[string]resourceAttributeContract{
+		"id":            computedString,
+		"hostname":      optionalComputedString,
+		"ip":            optionalComputedString,
+		"port":          optionalComputedInt64,
+		"use_ssl":       optionalComputedBool,
+		"url_base":      optionalComputedString,
+		"api_key":       optionalSensitiveString,
+		"external_url":  optionalComputedString,
+		"response_json": computedString,
+		"status_code":   computedInt64,
+	}, nil)
 }

--- a/internal/provider/resource_user_permissions_test.go
+++ b/internal/provider/resource_user_permissions_test.go
@@ -1,22 +1,14 @@
 package provider
 
-import (
-	"context"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-)
+import "testing"
 
 func TestUserPermissionsResourceSchema(t *testing.T) {
 	t.Parallel()
-	r := NewUserPermissionsResource()
-	var req resource.SchemaRequest
-	var resp resource.SchemaResponse
-	r.Schema(context.Background(), req, &resp)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Schema() returned diagnostics errors: %v", resp.Diagnostics)
-	}
-	if resp.Schema.Attributes == nil && resp.Schema.Blocks == nil {
-		t.Fatal("Schema() returned empty attributes and blocks")
-	}
+	assertResourceSchemaContract(t, NewUserPermissionsResource(), map[string]resourceAttributeContract{
+		"id":            computedString,
+		"user_id":       requiredInt64,
+		"permissions":   requiredInt64,
+		"response_json": computedString,
+		"status_code":   computedInt64,
+	}, nil)
 }


### PR DESCRIPTION
## Summary

- add required arguments to the Emby, Jellyfin, Plex library-settings, and job-run examples
- regenerate the four corresponding resource docs
- replace eight non-empty schema smoke tests with full attribute-contract assertions
- verify network nested block names for proxy and DNS cache settings

## Validation

- `go generate ./...`
- focused schema tests
- `bash ./scripts/test-all-locally.sh`
  - generated-file determinism
  - release reconciliation tests
  - `go build ./...`
  - `go test ./...`
  - OpenAPI coverage: 163 paths accounted for, 0 uncovered
  - OpenTofu module validation
- `git diff --check`

Local `golangci-lint` was skipped because the executable is not installed; CI remains authoritative for lint.

Fixes #167